### PR TITLE
[MIsoEnrich] Add non-integer stage numbers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,9 @@
+[submodule "external/CppNumericalSolvers"]
+	path = external/CppNumericalSolvers
+	url = https://github.com/PatWie/CppNumericalSolvers.git
+[submodule "external/eigen"]
+	path = external/eigen
+	url = https://gitlab.com/libeigen/eigen.git
+[submodule "external/json"]
+	path = external/json
+	url = https://github.com/nlohmann/json.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ SET(STUB_INCLUDE_DIRS ${STUB_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS})
 MESSAGE(STATUS "Finding and including submodules.")
 
 # Find Niels Lohmann's 'JSON for Modern C++' package
-FIND_PACKAGE(nlohmann_json REQUIRED)
+#FIND_PACKAGE(nlohmann_json REQUIRED)
 
 # The line below does not work!
 # For unknown reasons, CMake does not find the include directories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,11 @@ PROJECT(misoenrichment)
 
 # check for and enable c++11 support
 INCLUDE(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-IF(COMPILER_SUPPORTS_CXX11)
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
+IF(COMPILER_SUPPORTS_CXX14)
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 ELSE()
-  MESSAGE(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11
+  MESSAGE(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++14
   support. Please use a different C++ compiler.")
 ENDIF()
 
@@ -85,7 +85,7 @@ ENDIF("${isSystemDir}" STREQUAL "-1")
 # Tell CMake where the modules are
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_INSTALL_PREFIX}/share/cyclus/cmake")
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${STUB_SOURCE_DIR}/cmake)
-MESSAGE("--CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}")
+MESSAGE("-- CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}")
 
 # Find cyclus
 FIND_PACKAGE(Cyclus REQUIRED)
@@ -95,7 +95,7 @@ SET(LIBS ${LIBS} ${CYCLUS_CORE_LIBRARIES})
 # Include macros
 INCLUDE(UseCyclus)
 
-MESSAGE("--LD_LIBRARY_PATH: $ENV{LD_LIBRARY_PATH}")
+MESSAGE("-- LD_LIBRARY_PATH: $ENV{LD_LIBRARY_PATH}")
 
 # Include the boost header files, system, and filesystem libraries
 SET(Boost_USE_STATIC_LIBS       OFF)
@@ -124,12 +124,25 @@ set(LIBS ${LIBS} ${COIN_LIBRARIES})
 FIND_PACKAGE(PythonLibs REQUIRED)
 SET(STUB_INCLUDE_DIRS ${STUB_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS})
 
+# Find and include external libraries and submodules.
+MESSAGE(STATUS "Finding and including submodules.")
+
 # Find Niels Lohmann's 'JSON for Modern C++' package
 FIND_PACKAGE(nlohmann_json REQUIRED)
+
 # The line below does not work!
 # For unknown reasons, CMake does not find the include directories
 # and nlohmann_json_INCLUDE_DIRS is an unset variable.
-SET(STUB_INCLUDE_DIRS ${STUB_INCLUDE_DIRS} ${nlohmann_json_INCLUDE_DIRS})
+#SET(STUB_INCLUDE_DIRS ${STUB_INCLUDE_DIRS} ${nlohmann_json_DIR})
+
+MESSAGE(STATUS "Eigen")
+FIND_PATH(EIGEN_DIR Eigen external/eigen)
+SET(STUB_INCLUDE_DIRS ${STUB_INCLUDE_DIRS} ${EIGEN_DIR})
+
+MESSAGE(STATUS "CppNumericalSolvers")
+SET(CPP_NUMERICAL_SOLVERS_DIR "external/CppNumericalSolvers")
+FIND_PATH(CPP_NUMERICAL_SOLVERS_DIR CppNumericalSolvers external/CppNumericalSolvers)
+SET(STUB_INCLUDE_DIRS ${STUB_INCLUDE_DIRS} ${CPP_NUMERICAL_SOLVERS_DIR})
 
 # include all the directories we just found
 INCLUDE_DIRECTORIES(${STUB_INCLUDE_DIRS})

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2020-2022, RWTH Aachen University Nuclear Verification and Disarmament Group
+Copyright (c) 2020-2023, RWTH Aachen University Nuclear Verification and Disarmament Group
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # misoenrichment: a nuclear archaeology module for Cyclus
 ![GitHub](https://img.shields.io/github/license/maxschalz/miso_enrichment)
+![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
 
 `misoenrichment` is a module for the nuclear fuel cycle simulator
 [Cyclus](http://fuelcycle.org) and is developed at the

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # misoenrichment: a nuclear archaeology module for Cyclus
 ![GitHub](https://img.shields.io/github/license/maxschalz/miso_enrichment)
-![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-
+![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)]
 
 `misoenrichment` is a module for the nuclear fuel cycle simulator
 [Cyclus](http://fuelcycle.org) and is developed at the
@@ -25,15 +24,25 @@ on which input parameters are chosen, the source code of `GprReactor` may
 need minor tweaking. Additional information on this issue will be given
 in future commits.
 
-Table of Contents
-- [MIsoEnrich](#misoenrich)
-  - [Getting Started](#getting-started)
-  - [Theoretical background](#theoretical-background)
-- [GprReactor](#gprreactor)
-  - [Requirements](#requirements)
-- [References](#references)
-
 ## MIsoEnrich
+### Installation
+This module has some dependencies.
+Python dependencies ([`scipy`](https://github.com/scipy/scipy) and
+[`numpy`](https://github.com/numpy/numpy) are installed automatically via `pip`,
+while the C++ dependencies
+([CppOptimizationLibrary](https://github.com/PatWie/CppNumericalSolvers/tree/master),
+[Eigen](https://eigen.tuxfamily.org/) and
+[JSON for Modern C++](https://github.com/nlohmann/json)) are included as Git
+submodules.
+These need to be fetched first, as shown below:
+```
+$ git clone https://github.com/Nuclear-Verification-and-Disarmament/miso_enrichment.git
+$ cd miso_enrichment
+$ git submodule update --init --recursive  # Download C++ dependencies
+$ python3 install.py  # Install misoenrichment module
+$ misoenrichment_unit_tests  # Run unit tests (optional).
+```
+
 ### Getting started
 An example input file is found in `input/main.py` featuring a
 `cycamore::Source` source agent, a `MIsoEnrich` enrichment facility and two
@@ -48,8 +57,14 @@ sufficient). In fact, one cannot request a material with a certain
 concentration in minor isotopes or with a constraint on the minor isotopes
 concentration (e.g., to make it ASTM compliant, see Ref 4).
 
-Additionally, it should be noted that the facility supports downblending of
-uranium. This means that the facility tries to match the desired enrichment
+Additionally, it should be noted that the facility allows to select between
+integer number of stages (default) or decimal number of stages.
+The former option will exceed (undershoot) the desired product (tails) assay,
+the latter option will match both assays as close as possible.
+
+Also note that when using an integer number of stages, the facility supports
+downblending of uranium.
+This means that the facility tries to match the desired enrichment
 level as precise as possible by first enriching the uranium (to a higher
 level, as explained above) and then blending the product with uranium from
 the feed. This procedure is only performed if the `use_downblending`

--- a/README.md
+++ b/README.md
@@ -1,21 +1,24 @@
-# misoenrichment: a Cyclus multi component isotope enrichment module
+# misoenrichment: a nuclear archaeology module for Cyclus
 ![GitHub](https://img.shields.io/github/license/maxschalz/miso_enrichment)
 
-`misoenrichment` is a module developed at the [Nuclear Verification and Disarmament Group](https://www.nvd.rwth-aachen.de/) at RWTH Aachen University for the nuclear fuel cycle simulator
-[Cyclus](http://fuelcycle.org). It currently provides two Cyclus facilities. 
+`misoenrichment` is a module for the nuclear fuel cycle simulator
+[Cyclus](http://fuelcycle.org) and is developed at the
+[Nuclear Verification and Disarmament Group](https://www.nvd.rwth-aachen.de/)
+at RWTH Aachen University.
+It currently provides two Cyclus facilities, `MIsoEnrich` and `GprReactor`.
 
-`MIsoEnrich` is an enrichment facility that enriches 
-streams composed of two or more uranium isotopes taking into account the 
+`MIsoEnrich` is an enrichment facility that enriches
+streams composed of two or more uranium isotopes taking into account the
 different enrichment behaviour of minor isotopes such as <sup>234</sup>U (present in
-natural as well as in reprocessed uranium) or <sup>236</sup>U (present in 
+natural as well as in reprocessed uranium) or <sup>236</sup>U (present in
 reprocessed uranium from spent nuclear fuel). The tracking of minor
 isotopes makes this module suitable for nuclear archaeology, see, e.g., Ref 3.
 
-`GprReactor` is a Cyclus reactor facility that uses Gaussian Process 
+`GprReactor` is a Cyclus reactor facility that uses Gaussian Process
 Regression (GPR) to calculate the composition of the irradiated fuel depending
 on various input parameters. Generally, this implementation works for any
 reactor type and any input parameters. However, one needs the appropriate
-GPR model (which needs to be generated using training data) and depending 
+GPR model (which needs to be generated using training data) and depending
 on which input parameters are chosen, the source code of `GprReactor` may
 need minor tweaking. Additional information on this issue will be given
 in future commits.
@@ -32,32 +35,32 @@ Table of Contents
 ### Getting started
 An example input file is found in `input/main.py` featuring a
 `cycamore::Source` source agent, a `MIsoEnrich` enrichment facility and two
-`cycamore::Sink` agents, one for enriched and one for depleted uranium. 
+`cycamore::Sink` agents, one for enriched and one for depleted uranium.
 
-Note that the sink requests a binary composition of enriched uranium (90% 
+Note that the sink requests a binary composition of enriched uranium (90%
 <sup>235</sup>U, 10% <sup>238</sup> U) and that the enrichment facility
 enriches to a level at least equal to the requested one while keeping track
- of the minor isotopes. This implies that one does _not_ need to know the 
-final composition of enriched uranium beforehand (its desired assay is 
-sufficient). In fact, one cannot request a material with a certain 
+ of the minor isotopes. This implies that one does _not_ need to know the
+final composition of enriched uranium beforehand (its desired assay is
+sufficient). In fact, one cannot request a material with a certain
 concentration in minor isotopes or with a constraint on the minor isotopes
 concentration (e.g., to make it ASTM compliant, see Ref 4).
 
 Additionally, it should be noted that the facility supports downblending of
 uranium. This means that the facility tries to match the desired enrichment
-level as precise as possible by first enriching the uranium (to a higher 
+level as precise as possible by first enriching the uranium (to a higher
 level, as explained above) and then blending the product with uranium from
 the feed. This procedure is only performed if the `use_downblending`
 variable is set to `True` in the input file.
 
 ### Theoretical background
 The implementation of the facility itself and the interaction with Cyclus'
-Dynamic Resource Exchange is based on the binary enrichment facility from 
+Dynamic Resource Exchange is based on the binary enrichment facility from
 the [Cycamore](https://github.com/cyclus/cycamore) package.
 
 The multi-component isotope calculations are based on mainly on Refs 1 and 2.
 Ref 1 derives the mathematical formalism of a matched abundance ratio cascade
-using constant overall stage separation factors while Ref 2 gives a new 
+using constant overall stage separation factors while Ref 2 gives a new
 physically founded approach to calculating said separation factors.
 
 ## GprReactor
@@ -66,7 +69,7 @@ This facility needs Niels Lohmann's [JSON for Modern C++](https://json.nlohmann.
 library. It can be downloaded from his [GitHub repository](https://github.com/nlohmann/json)
 or using one of the many package managers, see [here](https://github.com/nlohmann/json#package-managers).
 Successfully tested using `conda install -c conda-forge nlohmann_json` and using `CMake`.
-When using `CMake`, then the package needs to be installed globally 
+When using `CMake`, then the package needs to be installed globally
 (i.e., under `/usr/local`), as shown in the following:
 ```
 $ git clone https://github.com/nlohmann/json
@@ -79,23 +82,23 @@ $ sudo make install
 ```
 While it _should_ be possible to install `JSON for Modern C++` locally,
 i.e. in `~/.local`, this results in `CMake` not finding `nlohmann/json.hpp`
-during the `misoenrichment` installation. I will hopefully manage to 
+during the `misoenrichment` installation. I will hopefully manage to
 fix this in future versions.
 
-Additionally, one needs `Python3` in combination with the `NumPy` and 
+Additionally, one needs `Python3` in combination with the `NumPy` and
 `SciPy` packages.
 
 ## References
 
-1. E. von Halle, _Multicomponent Isotope Separation in Matched Abundance 
-  Ratio Cascades Composed of Stages With Large Separation Factors_. 
+1. E. von Halle, _Multicomponent Isotope Separation in Matched Abundance
+  Ratio Cascades Composed of Stages With Large Separation Factors_.
   International Technology Programs (K/ITP--131). Oak Ridge, TN (1987).
-2. Houston G. Wood, _Effects of Separation Processes on Minor Uranium 
+2. Houston G. Wood, _Effects of Separation Processes on Minor Uranium
   Isotopes in Enrichment Cascades_. Science and Global Security, 16:26–36
   (2008), DOI: [10.1080/08929880802361796](https://doi.org/10.1080/08929880802361796).
-3. Steve Fetter, _Nuclear Archaeology: Verifying Declarations of 
+3. Steve Fetter, _Nuclear Archaeology: Verifying Declarations of
   Fissile-material Production_. Science and Global Security, 3:237-261
   (1993).
-4. ASTM International. _C787-20 Standard Specification for Uranium 
-  Hexafluoride for Enrichment_. West Conshohocken, PA; ASTM International, 2020. 
+4. ASTM International. _C787-20 Standard Specification for Uranium
+  Hexafluoride for Enrichment_. West Conshohocken, PA; ASTM International, 2020.
   DOI: [10.1520/C0787-20](https://doi.org/10.1520/C0787-20).

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ using constant overall stage separation factors while Ref 2 gives a new
 physically founded approach to calculating said separation factors.
 
 ## GprReactor
+:rotating_light: Please note that this module does not work at the moment.
+I do not manage to correctly include the JSON dependency in the build system and
+will have to investigate this further or even remove this package entirely.
+For updates see [issue #6](https://github.com/Nuclear-Verification-and-Disarmament/miso_enrichment/issues/6).
+
 ### Requirements
 This facility needs Niels Lohmann's [JSON for Modern C++](https://json.nlohmann.me/)
 library. It can be downloaded from his [GitHub repository](https://github.com/nlohmann/json)

--- a/input/archetypes.py
+++ b/input/archetypes.py
@@ -1,14 +1,16 @@
 def archetypes():
-    d = {"archetypes": {
-           "spec": [
-             {"lib": "agents", "name": "NullInst"},
-             {"lib": "agents", "name": "NullRegion"},
-             {"lib": "cycamore", "name": "Sink"},
-             {"lib": "cycamore", "name": "Source"},
-             {"lib": "cycamore", "name": "Storage"},
-             {"lib": "misoenrichment", "name": "GprReactor"},
-             {"lib": "misoenrichment", "name": "MIsoEnrich"}
-           ]
-         }}
+    d = {
+        "archetypes": {
+            "spec": [
+                {"lib": "agents", "name": "NullInst"},
+                {"lib": "agents", "name": "NullRegion"},
+                {"lib": "cycamore", "name": "Sink"},
+                {"lib": "cycamore", "name": "Source"},
+                {"lib": "cycamore", "name": "Storage"},
+                {"lib": "misoenrichment", "name": "GprReactor"},
+                {"lib": "misoenrichment", "name": "MIsoEnrich"},
+            ]
+        }
+    }
 
     return d

--- a/input/commodity.py
+++ b/input/commodity.py
@@ -1,6 +1,8 @@
 def commodity():
-    d = {"commodity": [
-          {"name": "EnrichedU", "solution_priority": 2},
-          {"name": "DepletedU", "solution_priority": 2}
-        ]}
+    d = {
+        "commodity": [
+            {"name": "EnrichedU", "solution_priority": 2},
+            {"name": "DepletedU", "solution_priority": 2},
+        ]
+    }
     return d

--- a/input/control.py
+++ b/input/control.py
@@ -1,10 +1,11 @@
 def control():
-    d = {"control": {
-           "startyear": 2020,
-           "startmonth": 1,
-           "duration": 365,
-           "dt": 86400, # duration of a time step in seconds, here: 1 day
-           "simhandle": "misoenrichment tutorial file",
-           }
+    d = {
+        "control": {
+            "startyear": 2020,
+            "startmonth": 1,
+            "duration": 365,
+            "dt": 86400,  # duration of a time step in seconds, here: 1 day
+            "simhandle": "misoenrichment tutorial file",
         }
+    }
     return d

--- a/input/facility.py
+++ b/input/facility.py
@@ -51,6 +51,7 @@ def facility():
                         "swu_capacity_vals": {"val": [1e5, 5e4, 5e5]},
                         "swu_capacity_times": {"val": [0, 5, 6]},
                         "use_downblending": True,
+                        "use_integer_stages": True,  # Must be 'True' because downblending is enabled
                     }
                 },
             },

--- a/input/facility.py
+++ b/input/facility.py
@@ -1,66 +1,76 @@
 def facility():
-    d = {"facility": [
-          {
-            "name": "NaturalUSource",
-            "config": {"Source": {
-              "outcommod": "NaturalU",
-              "outrecipe": "NaturalURecipe",
-              "throughput": 10000
-            }}
-          },
-          {
-            "name": "SpentFuelSink",
-            "config": {"Sink": {
-              "in_commods": {"val": ["SpentFuel"]}
-            }}
-          },
-          {
-            "name": "DepletedUSink",
-            "config": {"Sink": {
-              "in_commods": {"val": ["DepletedU"]},
-              "recipe_name": "DepletedURecipe"
-            }}
-          },
-          {
-            "name": "FreshFuelStorage",
-            "config": {"Storage": {
-              "in_commods": {"val": ["EnrichedU"]},
-              "out_commods": {"val": ["FreshFuel"]},
-              "in_recipe": ["EnrichedURecipe"],
-              "residence_time": 0
-            }}
-          },
-          {
-            "name": "EnrichmentFacility",
-            "config": {"MIsoEnrich": {
-              "feed_commod": "NaturalU",
-              "feed_recipe": "NaturalURecipe",
-              "product_commod": "EnrichedU",
-              "tails_commod": "DepletedU",
-              "tails_assay": 0.003,
-              "initial_feed": 0,
-              "max_feed_inventory": 1e299,
-              "gamma_235": 1.35,
-              "swu_capacity": 1e299,
-              "swu_capacity_vals": {"val": [1e5, 5e4, 5e5]},
-              "swu_capacity_times": {"val": [0, 5, 6]},
-              "use_downblending": True
-            }}
-          },
-          {
-            "name": "SavannahRiverReactor",
-            "config": {"GprReactor": {
-              "in_commods": {"val": ["FreshFuel"]},
-              "out_commods": {"val": ["SpentFuel"]},
-              "in_recipes": {"val": ["EnrichedURecipe"]},
-              "n_assem_core": 1,
-              "n_assem_batch": 1,
-              "assem_size": 110820,
-              "cycle_time": 88,
-              "refuel_time": 6,
-              "power_output": 2400,
-              "temperature": 350
-            }}
-          }
-        ]}
+    d = {
+        "facility": [
+            {
+                "name": "NaturalUSource",
+                "config": {
+                    "Source": {
+                        "outcommod": "NaturalU",
+                        "outrecipe": "NaturalURecipe",
+                        "throughput": 10000,
+                    }
+                },
+            },
+            {
+                "name": "SpentFuelSink",
+                "config": {"Sink": {"in_commods": {"val": ["SpentFuel"]}}},
+            },
+            {
+                "name": "DepletedUSink",
+                "config": {
+                    "Sink": {
+                        "in_commods": {"val": ["DepletedU"]},
+                        "recipe_name": "DepletedURecipe",
+                    }
+                },
+            },
+            {
+                "name": "FreshFuelStorage",
+                "config": {
+                    "Storage": {
+                        "in_commods": {"val": ["EnrichedU"]},
+                        "out_commods": {"val": ["FreshFuel"]},
+                        "in_recipe": ["EnrichedURecipe"],
+                        "residence_time": 0,
+                    }
+                },
+            },
+            {
+                "name": "EnrichmentFacility",
+                "config": {
+                    "MIsoEnrich": {
+                        "feed_commod": "NaturalU",
+                        "feed_recipe": "NaturalURecipe",
+                        "product_commod": "EnrichedU",
+                        "tails_commod": "DepletedU",
+                        "tails_assay": 0.003,
+                        "initial_feed": 0,
+                        "max_feed_inventory": 1e299,
+                        "gamma_235": 1.35,
+                        "swu_capacity": 1e299,
+                        "swu_capacity_vals": {"val": [1e5, 5e4, 5e5]},
+                        "swu_capacity_times": {"val": [0, 5, 6]},
+                        "use_downblending": True,
+                    }
+                },
+            },
+            {
+                "name": "SavannahRiverReactor",
+                "config": {
+                    "GprReactor": {
+                        "in_commods": {"val": ["FreshFuel"]},
+                        "out_commods": {"val": ["SpentFuel"]},
+                        "in_recipes": {"val": ["EnrichedURecipe"]},
+                        "n_assem_core": 1,
+                        "n_assem_batch": 1,
+                        "assem_size": 110820,
+                        "cycle_time": 88,
+                        "refuel_time": 6,
+                        "power_output": 2400,
+                        "temperature": 350,
+                    }
+                },
+            },
+        ]
+    }
     return d

--- a/input/institution.py
+++ b/input/institution.py
@@ -1,15 +1,19 @@
 import facility
 
+
 def institution():
     fac = facility.facility()
-    d = {"institution": [
-           {
-             "name": "MyInstitution",
-             "config": {"NullInst": None},
-             "initialfacilitylist": {
-               "entry": [{"number": 1, "prototype": f["name"]} 
-                        for f in fac["facility"]]
-             }
-           }
-        ]}
+    d = {
+        "institution": [
+            {
+                "name": "MyInstitution",
+                "config": {"NullInst": None},
+                "initialfacilitylist": {
+                    "entry": [
+                        {"number": 1, "prototype": f["name"]} for f in fac["facility"]
+                    ]
+                },
+            }
+        ]
+    }
     return d

--- a/input/main.py
+++ b/input/main.py
@@ -1,6 +1,7 @@
 import sys
-sys.path.append('./')
-sys.path.append('./input')
+
+sys.path.append("./")
+sys.path.append("./input")
 
 import archetypes
 import commodity
@@ -9,6 +10,7 @@ import facility
 import recipe
 import region
 
+
 def simulation():
     arch = archetypes.archetypes()
     commod = commodity.commodity()
@@ -16,6 +18,5 @@ def simulation():
     fac = facility.facility()
     recipes = recipe.recipe()
     reg = region.region()
-    
-    return {"simulation": {**arch, **commod, **ctrl, **fac, **recipes, 
-                           **reg}}
+
+    return {"simulation": {**arch, **commod, **ctrl, **fac, **recipes, **reg}}

--- a/input/recipe.py
+++ b/input/recipe.py
@@ -1,31 +1,27 @@
 def recipe():
-    d = {"recipe": [
-          {
-            "name": "NaturalURecipe",
-            "basis": "mass",
-            "nuclide": [
-              # At the moment (May 2021), U234 is not taken into
-              # account by the Gpr model.
-              #{"id": "U234", "comp": 5.5e-3},
-              {"id": "U235", "comp": 0.711},
-              {"id": "U238", "comp": 100 - 0.711}
-            ]
-          },
-          {
-            "name": "EnrichedURecipe",
-            "basis": "mass",
-            "nuclide": [
-              {"id": "U235", "comp": 1.1},
-              {"id": "U238", "comp": 98.9}
-            ]
-          },
-          {
-            "name": "DepletedURecipe",
-            "basis": "mass",
-            "nuclide": [
-              {"id": "U235", "comp": 0.3},
-              {"id": "U238", "comp": 99.7}
-            ]
-          }
-        ]}
+    d = {
+        "recipe": [
+            {
+                "name": "NaturalURecipe",
+                "basis": "mass",
+                "nuclide": [
+                    # At the moment (May 2021), U234 is not taken into
+                    # account by the Gpr model.
+                    # {"id": "U234", "comp": 5.5e-3},
+                    {"id": "U235", "comp": 0.711},
+                    {"id": "U238", "comp": 100 - 0.711},
+                ],
+            },
+            {
+                "name": "EnrichedURecipe",
+                "basis": "mass",
+                "nuclide": [{"id": "U235", "comp": 1.1}, {"id": "U238", "comp": 98.9}],
+            },
+            {
+                "name": "DepletedURecipe",
+                "basis": "mass",
+                "nuclide": [{"id": "U235", "comp": 0.3}, {"id": "U238", "comp": 99.7}],
+            },
+        ]
+    }
     return d

--- a/input/region.py
+++ b/input/region.py
@@ -1,12 +1,15 @@
 import institution
 
+
 def region():
     inst = institution.institution()
-    d = {"region": [
-          {
-            "name": "MyRegion",
-            "config": {"NullRegion": None},
-            "institution": inst["institution"]
-          }
-        ]}
+    d = {
+        "region": [
+            {
+                "name": "MyRegion",
+                "config": {"NullRegion": None},
+                "institution": inst["institution"],
+            }
+        ]
+    }
     return d

--- a/spentfuelgpr/setup.py
+++ b/spentfuelgpr/setup.py
@@ -3,6 +3,7 @@
 
 from setuptools import setup
 
+
 def main():
     setup(
         name="spentfuelgpr",
@@ -12,11 +13,14 @@ def main():
         url="https://github.com/maxschalz/miso_enrichment/",
         license="BSD-3-Clause",
         packages=["spentfuelgpr"],
-        classifiers=["License :: OSI Approved :: BSD-3-Clause License",
-                     "Programming Language :: Python :: 3"],
-        install_requires=["numpy", "scipy"]
+        classifiers=[
+            "License :: OSI Approved :: BSD-3-Clause License",
+            "Programming Language :: Python :: 3",
+        ],
+        install_requires=["numpy", "scipy"],
     )
     return
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     main()

--- a/spentfuelgpr/spentfuelgpr/kernel.py
+++ b/spentfuelgpr/spentfuelgpr/kernel.py
@@ -18,15 +18,15 @@ from scipy.spatial.distance import cdist
 def Kernel(X1, X2, Type, *params, gradient=False):
     '''
     All the kernels have a bit of noise added in order to prevent the covariance
-    matrix becoming singular. The amount of noise to be added is also a 
+    matrix becoming singular. The amount of noise to be added is also a
     parameter to reconstruct
     '''
-    
+
     def dif(array1, array2):
         Output = [array1[i] - array2[i] for i in range(len(array1))]
         Output = np.array(Output).ravel()
         return sum(Output)
-    
+
     if Type == 'SQE':
         sqdist = np.sum(X1**2, 1).reshape(-1, 1) + np.sum(X2**2, 1) - 2 * np.dot(X1, X2.T)
         K = (params[0][0]**2) * np.exp(-0.5  * sqdist / params[0][1]**2 ) +\
@@ -37,7 +37,7 @@ def Kernel(X1, X2, Type, *params, gradient=False):
             return K, gradients
         else:
             return K
-        
+
     if Type == 'ASQE':
         LAMBDA = np.eye(len(X2[0]))
         length_scales = 1/params[0][1:-1]
@@ -50,12 +50,12 @@ def Kernel(X1, X2, Type, *params, gradient=False):
             ((params[0][-1]**2)*np.eye(X1.shape[0]))
         if gradient:
             g = [cdist(np.expand_dims(X1[:,i],-1),
-                       np.expand_dims(X2[:,i],-1), 
+                       np.expand_dims(X2[:,i],-1),
                        metric='sqeuclidean')/(params[0][i+1]) \
                  for i in range(X1.shape[1]) ]
-            gradients = [np.multiply(g[i],K) for i in range(X1.shape[1])]    
+            gradients = [np.multiply(g[i],K) for i in range(X1.shape[1])]
             gradients = [2*params[0][0]*K] + gradients + [2*params[0][-1]*np.eye(X1.shape[0])]
- 
+
             return K, gradients
         else:
             return K
@@ -77,16 +77,16 @@ def Kernel(X1, X2, Type, *params, gradient=False):
             ((params[0][-1]**2)*np.eye(X1.shape[0]))
         if gradient:
             g = [cdist(np.expand_dims(X1[:,i]/params[0][i+1],-1),
-                       np.expand_dims(X2[:,i]/params[0][i+1],-1), 
+                       np.expand_dims(X2[:,i]/params[0][i+1],-1),
                        metric='euclidean')/(params[0][i+1]) \
                  for i in range(X1.shape[1]) ]
-            gradients = [np.multiply(g[i],K) for i in range(X1.shape[1])]    
+            gradients = [np.multiply(g[i],K) for i in range(X1.shape[1])]
             gradients = [2*params[0][0]*K] + gradients + [2*params[0][-1]*np.eye(X1.shape[0])]
-            
+
             return K, gradients
         else:
             return K
-        
+
     if Type == 'Linear':
         # This is a version of Linear modified to include lengthscales for each
         # Input Variable
@@ -97,21 +97,21 @@ def Kernel(X1, X2, Type, *params, gradient=False):
         length_scales = 1/params[0][2:-1]
         np.fill_diagonal(LAMBDA,length_scales)
         X1 = np.dot(X1,LAMBDA)
-        X2 = np.dot(X2,LAMBDA) 
+        X2 = np.dot(X2,LAMBDA)
         K = (params[0][0]*np.dot(X1,X2.T).T)+params[0][1] +\
             ((params[0][-1]**2)*np.eye(X1.shape[0]))
-  
+
         if gradient:
             gradients = [np.dot(X1,X2.T).T] + [np.eye(K.shape[0])] + [2*params[0][0]*\
                                                    np.dot(np.expand_dims(X1[:,i],-1)
                                                           ,np.expand_dims(X2[:,i],-1).T).T/\
                                                        params[0][i]\
-                                                       for i in range(X1.shape[1])] 
+                                                       for i in range(X1.shape[1])]
             gradients = gradients + [2*params[0][-1]*np.eye(X1.shape[0])]
             return K, gradients
         else:
             return K
-        
+
     if Type == 'Poly':
 # =============================================================================
 #         K = (a*(X.Y)+b)**c
@@ -120,7 +120,7 @@ def Kernel(X1, X2, Type, *params, gradient=False):
         length_scales = 1/params[0][3:-1]
         np.fill_diagonal(LAMBDA,length_scales)
         X1 = np.dot(X1,LAMBDA)
-        X2 = np.dot(X2,LAMBDA) 
+        X2 = np.dot(X2,LAMBDA)
         K = ((params[0][0]*np.dot(X1,X2.T).T)+params[0][1])**params[0][2] +\
             ((params[0][-1]**2)*np.eye(X1.shape[0]))
 
@@ -137,7 +137,7 @@ def Kernel(X1, X2, Type, *params, gradient=False):
             return K, gradients
         else:
             return K
-        return 
+        return
     if Type == 'Anova':
         # This isn't working, probably some parameters for lengthscales are needed for each dimension
         K = np.exp((-params[0][0]*cdist(X1,X2, metric='sqeuclidean'))**params[0][1]) +\
@@ -153,10 +153,10 @@ def Kernel(X1, X2, Type, *params, gradient=False):
                          -np.multiply(cdist(X1**3 , X2**3, metric='sqeuclidean'),dd), dd,
                          2*params[0][-1]*np.eye(X1.shape[0])]
             return K, gradients
-        
+
         else:
             return K
-      
+
     if Type == 'Sigmoid':
         # This is not a positive semidefinite Kernel. Some tweaking has to be done
         # to make this work. Probably along the lines of KdotK.T
@@ -170,7 +170,7 @@ def Kernel(X1, X2, Type, *params, gradient=False):
          # This isn't working, probably some parameters for lengthscales are needed for each dimension
         else:
             return K
-    
+
     if Type == 'RQ':
         LAMBDA = np.eye(len(X1[0]))
         length_scales = 1/params[0][1:-1]
@@ -180,22 +180,22 @@ def Kernel(X1, X2, Type, *params, gradient=False):
         sqdist = cdist(X1 , X2, metric='sqeuclidean').T
         K = 1 - (sqdist/(sqdist+(params[0][0])**2)) +\
             ((params[0][-1]**2)*np.eye(X1.shape[0]))
-        
+
         if gradient:
             denom = 1/((sqdist+(params[0][0])**2))**2
             g = [cdist(np.expand_dims(X1[:,i],-1),
-                       np.expand_dims(X2[:,i],-1), 
+                       np.expand_dims(X2[:,i],-1),
                        metric='sqeuclidean')/(params[0][i+1]) \
                  for i in range(X1.shape[1]) ]
-            gradients = [-2*denom*g[i]*(params[0][0])**2 for i in range(X1.shape[1])] 
+            gradients = [-2*denom*g[i]*(params[0][0])**2 for i in range(X1.shape[1])]
             gradients = [2*params[0][0]*sqdist*denom] + gradients +\
                 [2*params[0][-1]*np.eye(X1.shape[0])]
             return K, gradients
-        
+
         else:
             return K
-        
-    
+
+
     if Type == 'SRQ':
         LAMBDA = np.eye(len(X1[0]))
         length_scales = 1/params[0][:-1]
@@ -204,7 +204,7 @@ def Kernel(X1, X2, Type, *params, gradient=False):
         X2 = np.dot(X2,LAMBDA)
         sqdist = cdist(X1 , X2, metric='sqeuclidean').T
         return (1/(1 + (sqdist/params[0][-1])) )**params[0][-1]
-    
+
     if Type == 'MultiQuad':
         # This Kernel is not positive semidefinite so a lot of tweaking would
         # have to be done to make this work. Maybe take some product of KdotK.T
@@ -218,14 +218,14 @@ def Kernel(X1, X2, Type, *params, gradient=False):
             ((params[0][-1]**2)*np.eye(X1.shape[0]))
         if gradient:
             g = [cdist(np.expand_dims(X1[:,i],-1),
-                       np.expand_dims(X2[:,i],-1), 
+                       np.expand_dims(X2[:,i],-1),
                        metric='sqeuclidean')/(params[0][i+1]) \
                  for i in range(X1.shape[1]) ]
-            gradients = [np.multiply(g[i],1/K) for i in range(X1.shape[1])]    
+            gradients = [np.multiply(g[i],1/K) for i in range(X1.shape[1])]
             gradients = [params[0][0]/K] + gradients +\
                 [2*params[0][-1]*np.eye(X1.shape[0])]
             return K, gradients
-        
+
         else:
             return K
 
@@ -239,13 +239,13 @@ def Kernel(X1, X2, Type, *params, gradient=False):
         K = 1/sqdist + ((params[0][-1]**2)*np.eye(X1.shape[0]))
         if gradient:
             g = [cdist(np.expand_dims(X1[:,i],-1),
-                       np.expand_dims(X2[:,i],-1), 
+                       np.expand_dims(X2[:,i],-1),
                        metric='sqeuclidean')/(params[0][i+1]) \
                  for i in range(X1.shape[1]) ]
-            gradients = [-np.multiply(g[i],K**3) for i in range(X1.shape[1])]  
+            gradients = [-np.multiply(g[i],K**3) for i in range(X1.shape[1])]
             gradients = [-params[0][0]*(K**3)] +  gradients +\
                 [2*params[0][-1]*np.eye(X1.shape[0])]
-            
+
             return K, gradients
         else:
             return K
@@ -260,23 +260,23 @@ def Kernel(X1, X2, Type, *params, gradient=False):
             return K, gradients
         else:
             return K
-       
+
     if Type == 'Power':
         K = cdist(X1/params[0][1:-1],X2/params[0][1:-1], metric='euclidean')**params[0][0] +\
             ((params[0][-1]**2)*np.eye(X1.shape[0]))
         if gradient:
-            dd = params[0][0] * cdist(X1/params[0][1:-1],X2/params[0][1:-1], 
+            dd = params[0][0] * cdist(X1/params[0][1:-1],X2/params[0][1:-1],
                                       metric='euclidean')**(params[0][0]-1)
             g = [cdist(np.expand_dims(X1[:,i]/params[0][i+1],-1),
-                       np.expand_dims(X2[:,i]/params[0][i+1],-1), 
+                       np.expand_dims(X2[:,i]/params[0][i+1],-1),
                        metric='sqeuclidean')/(params[0][i+1]) \
                  for i in range(X1.shape[1]) ]
-            gradients = [np.multiply(g[i],dd) for i in range(X1.shape[1])]  
+            gradients = [np.multiply(g[i],dd) for i in range(X1.shape[1])]
             gradients = [dd] +  gradients + [2*params[0][-1]*np.eye(X1.shape[0])]
             return K, gradients
         else:
             return K
-    
+
     if Type == 'Log':
         # This is a non positive definite Kernel
         dist = cdist(X1 , X2, metric='euclidean').T
@@ -301,7 +301,7 @@ def Kernel(X1, X2, Type, *params, gradient=False):
             return K, gradients
         else:
             return K
- 
+
     if Type == 'Tstudent':
         # This isn't working at the moment
         LAMBDA = np.eye(len(X1[0]))
@@ -314,11 +314,11 @@ def Kernel(X1, X2, Type, *params, gradient=False):
             ((params[0][-1]**2)*np.eye(X1.shape[0]))
         if gradient:
             da = -(sqdist**params[0][0])*np.log(sqdist)*(K**2)
-            arg = (sqdist**(params[0][0]-2))*(K**2) 
+            arg = (sqdist**(params[0][0]-2))*(K**2)
             gradients =  [da] + [params[0][0]*np.multiply(
                 cdist(np.expand_dims(X1[:,i],-1),
-                       np.expand_dims(X2[:,i],-1), 
-                       metric='sqeuclidean')/(params[0][i+1]),arg) 
+                       np.expand_dims(X2[:,i],-1),
+                       metric='sqeuclidean')/(params[0][i+1]),arg)
                                  for i in range(X1.shape[1])] +\
                 [2*params[0][-1]*np.eye(X1.shape[0])]
             return K, gradients

--- a/spentfuelgpr/spentfuelgpr/kernel.py
+++ b/spentfuelgpr/spentfuelgpr/kernel.py
@@ -15,313 +15,454 @@ __all__ = ["Kernel"]
 import numpy as np
 from scipy.spatial.distance import cdist
 
+
 def Kernel(X1, X2, Type, *params, gradient=False):
-    '''
+    """
     All the kernels have a bit of noise added in order to prevent the covariance
     matrix becoming singular. The amount of noise to be added is also a
     parameter to reconstruct
-    '''
+    """
 
     def dif(array1, array2):
         Output = [array1[i] - array2[i] for i in range(len(array1))]
         Output = np.array(Output).ravel()
         return sum(Output)
 
-    if Type == 'SQE':
-        sqdist = np.sum(X1**2, 1).reshape(-1, 1) + np.sum(X2**2, 1) - 2 * np.dot(X1, X2.T)
-        K = (params[0][0]**2) * np.exp(-0.5  * sqdist / params[0][1]**2 ) +\
-            ((params[0][-1]**2)*np.eye(X1.shape[0]))
+    if Type == "SQE":
+        sqdist = (
+            np.sum(X1**2, 1).reshape(-1, 1)
+            + np.sum(X2**2, 1)
+            - 2 * np.dot(X1, X2.T)
+        )
+        K = (params[0][0] ** 2) * np.exp(-0.5 * sqdist / params[0][1] ** 2) + (
+            (params[0][-1] ** 2) * np.eye(X1.shape[0])
+        )
         if gradient:
-            gradients = [2*params[0][0]*K,np.multiply(sqdist/(params[0][1]**3),K),
-                         2*params[0][-1]*np.eye(X1.shape[0])]
+            gradients = [
+                2 * params[0][0] * K,
+                np.multiply(sqdist / (params[0][1] ** 3), K),
+                2 * params[0][-1] * np.eye(X1.shape[0]),
+            ]
             return K, gradients
         else:
             return K
 
-    if Type == 'ASQE':
+    if Type == "ASQE":
         LAMBDA = np.eye(len(X2[0]))
-        length_scales = 1/params[0][1:-1]
-        np.fill_diagonal(LAMBDA,length_scales)
+        length_scales = 1 / params[0][1:-1]
+        np.fill_diagonal(LAMBDA, length_scales)
 
-        X1 = np.dot(X1,LAMBDA)
-        X2 = np.dot(X2,LAMBDA)
-        sqdist = cdist(X1 , X2, metric='sqeuclidean').T
-        K = (params[0][0]**2) * np.exp(-0.5  * sqdist) +\
-            ((params[0][-1]**2)*np.eye(X1.shape[0]))
+        X1 = np.dot(X1, LAMBDA)
+        X2 = np.dot(X2, LAMBDA)
+        sqdist = cdist(X1, X2, metric="sqeuclidean").T
+        K = (params[0][0] ** 2) * np.exp(-0.5 * sqdist) + (
+            (params[0][-1] ** 2) * np.eye(X1.shape[0])
+        )
         if gradient:
-            g = [cdist(np.expand_dims(X1[:,i],-1),
-                       np.expand_dims(X2[:,i],-1),
-                       metric='sqeuclidean')/(params[0][i+1]) \
-                 for i in range(X1.shape[1]) ]
-            gradients = [np.multiply(g[i],K) for i in range(X1.shape[1])]
-            gradients = [2*params[0][0]*K] + gradients + [2*params[0][-1]*np.eye(X1.shape[0])]
+            g = [
+                cdist(
+                    np.expand_dims(X1[:, i], -1),
+                    np.expand_dims(X2[:, i], -1),
+                    metric="sqeuclidean",
+                )
+                / (params[0][i + 1])
+                for i in range(X1.shape[1])
+            ]
+            gradients = [np.multiply(g[i], K) for i in range(X1.shape[1])]
+            gradients = (
+                [2 * params[0][0] * K]
+                + gradients
+                + [2 * params[0][-1] * np.eye(X1.shape[0])]
+            )
 
             return K, gradients
         else:
             return K
 
-    if Type == 'LAP':
-        dist = np.sqrt(np.sum(X1**2, 1).reshape(-1, 1) + np.sum(X2**2, 1) - 2 * np.dot(X1, X2.T))
-        K = (params[0][0]**2) * np.exp(-0.5  * dist / params[0][1] ) +\
-            ((params[0][-1]**2)*np.eye(X1.shape[0]))
+    if Type == "LAP":
+        dist = np.sqrt(
+            np.sum(X1**2, 1).reshape(-1, 1)
+            + np.sum(X2**2, 1)
+            - 2 * np.dot(X1, X2.T)
+        )
+        K = (params[0][0] ** 2) * np.exp(-0.5 * dist / params[0][1]) + (
+            (params[0][-1] ** 2) * np.eye(X1.shape[0])
+        )
         if gradient:
-            gradients = [2*params[0][0]*K,np.multiply(dist/(params[0][1]**2),K),
-                         2*params[0][-1]*np.eye(X1.shape[0])]
+            gradients = [
+                2 * params[0][0] * K,
+                np.multiply(dist / (params[0][1] ** 2), K),
+                2 * params[0][-1] * np.eye(X1.shape[0]),
+            ]
             return K, gradients
         else:
             return K
 
-    if Type == 'ALAP':
-        dist = np.sqrt(cdist(X1/params[0][1:-1],X2/params[0][1:-1], metric='euclidean').T)
-        K = (params[0][0]**2) * np.exp(-0.5  * dist) +\
-            ((params[0][-1]**2)*np.eye(X1.shape[0]))
+    if Type == "ALAP":
+        dist = np.sqrt(
+            cdist(X1 / params[0][1:-1], X2 / params[0][1:-1], metric="euclidean").T
+        )
+        K = (params[0][0] ** 2) * np.exp(-0.5 * dist) + (
+            (params[0][-1] ** 2) * np.eye(X1.shape[0])
+        )
         if gradient:
-            g = [cdist(np.expand_dims(X1[:,i]/params[0][i+1],-1),
-                       np.expand_dims(X2[:,i]/params[0][i+1],-1),
-                       metric='euclidean')/(params[0][i+1]) \
-                 for i in range(X1.shape[1]) ]
-            gradients = [np.multiply(g[i],K) for i in range(X1.shape[1])]
-            gradients = [2*params[0][0]*K] + gradients + [2*params[0][-1]*np.eye(X1.shape[0])]
+            g = [
+                cdist(
+                    np.expand_dims(X1[:, i] / params[0][i + 1], -1),
+                    np.expand_dims(X2[:, i] / params[0][i + 1], -1),
+                    metric="euclidean",
+                )
+                / (params[0][i + 1])
+                for i in range(X1.shape[1])
+            ]
+            gradients = [np.multiply(g[i], K) for i in range(X1.shape[1])]
+            gradients = (
+                [2 * params[0][0] * K]
+                + gradients
+                + [2 * params[0][-1] * np.eye(X1.shape[0])]
+            )
 
             return K, gradients
         else:
             return K
 
-    if Type == 'Linear':
+    if Type == "Linear":
         # This is a version of Linear modified to include lengthscales for each
         # Input Variable
-# =============================================================================
-#         K = a*X.Y+b
-# =============================================================================
+        # =============================================================================
+        #         K = a*X.Y+b
+        # =============================================================================
         LAMBDA = np.eye(len(params[0][2:-1]))
-        length_scales = 1/params[0][2:-1]
-        np.fill_diagonal(LAMBDA,length_scales)
-        X1 = np.dot(X1,LAMBDA)
-        X2 = np.dot(X2,LAMBDA)
-        K = (params[0][0]*np.dot(X1,X2.T).T)+params[0][1] +\
-            ((params[0][-1]**2)*np.eye(X1.shape[0]))
+        length_scales = 1 / params[0][2:-1]
+        np.fill_diagonal(LAMBDA, length_scales)
+        X1 = np.dot(X1, LAMBDA)
+        X2 = np.dot(X2, LAMBDA)
+        K = (
+            (params[0][0] * np.dot(X1, X2.T).T)
+            + params[0][1]
+            + ((params[0][-1] ** 2) * np.eye(X1.shape[0]))
+        )
 
         if gradient:
-            gradients = [np.dot(X1,X2.T).T] + [np.eye(K.shape[0])] + [2*params[0][0]*\
-                                                   np.dot(np.expand_dims(X1[:,i],-1)
-                                                          ,np.expand_dims(X2[:,i],-1).T).T/\
-                                                       params[0][i]\
-                                                       for i in range(X1.shape[1])]
-            gradients = gradients + [2*params[0][-1]*np.eye(X1.shape[0])]
+            gradients = (
+                [np.dot(X1, X2.T).T]
+                + [np.eye(K.shape[0])]
+                + [
+                    2
+                    * params[0][0]
+                    * np.dot(
+                        np.expand_dims(X1[:, i], -1), np.expand_dims(X2[:, i], -1).T
+                    ).T
+                    / params[0][i]
+                    for i in range(X1.shape[1])
+                ]
+            )
+            gradients = gradients + [2 * params[0][-1] * np.eye(X1.shape[0])]
             return K, gradients
         else:
             return K
 
-    if Type == 'Poly':
-# =============================================================================
-#         K = (a*(X.Y)+b)**c
-# =============================================================================
+    if Type == "Poly":
+        # =============================================================================
+        #         K = (a*(X.Y)+b)**c
+        # =============================================================================
         LAMBDA = np.eye(len(params[0][3:-1]))
-        length_scales = 1/params[0][3:-1]
-        np.fill_diagonal(LAMBDA,length_scales)
-        X1 = np.dot(X1,LAMBDA)
-        X2 = np.dot(X2,LAMBDA)
-        K = ((params[0][0]*np.dot(X1,X2.T).T)+params[0][1])**params[0][2] +\
-            ((params[0][-1]**2)*np.eye(X1.shape[0]))
+        length_scales = 1 / params[0][3:-1]
+        np.fill_diagonal(LAMBDA, length_scales)
+        X1 = np.dot(X1, LAMBDA)
+        X2 = np.dot(X2, LAMBDA)
+        K = ((params[0][0] * np.dot(X1, X2.T).T) + params[0][1]) ** params[0][2] + (
+            (params[0][-1] ** 2) * np.eye(X1.shape[0])
+        )
 
         if gradient:
-            db = params[0][2]*((params[0][0]*np.dot(X1,X2.T))+params[0][1])**(params[0][2]-1)
-            da = np.multiply(np.dot(X1,X2.T),db)
-            dc =  np.multiply(K,np.log((params[0][0]*np.dot(X1,X2.T)) + params[0][1]))
-            gradients = [da,db,dc]+\
-                [2*params[0][0]*np.multiply(np.dot(np.expand_dims(X1[:,i],-1),
-                                                    np.expand_dims(X2[:,i],-1).T)/\
-                                             params[0][i],db) \
-                 for i in range(X1.shape[1])]
-            gradients = gradients + [2*params[0][-1]*np.eye(X1.shape[0])]
+            db = params[0][2] * ((params[0][0] * np.dot(X1, X2.T)) + params[0][1]) ** (
+                params[0][2] - 1
+            )
+            da = np.multiply(np.dot(X1, X2.T), db)
+            dc = np.multiply(
+                K, np.log((params[0][0] * np.dot(X1, X2.T)) + params[0][1])
+            )
+            gradients = [da, db, dc] + [
+                2
+                * params[0][0]
+                * np.multiply(
+                    np.dot(np.expand_dims(X1[:, i], -1), np.expand_dims(X2[:, i], -1).T)
+                    / params[0][i],
+                    db,
+                )
+                for i in range(X1.shape[1])
+            ]
+            gradients = gradients + [2 * params[0][-1] * np.eye(X1.shape[0])]
             return K, gradients
         else:
             return K
         return
-    if Type == 'Anova':
+    if Type == "Anova":
         # This isn't working, probably some parameters for lengthscales are needed for each dimension
-        K = np.exp((-params[0][0]*cdist(X1,X2, metric='sqeuclidean'))**params[0][1]) +\
-            np.exp((-params[0][0]*cdist(X1**2,X2**2, metric='sqeuclidean'))**params[0][1])+ \
-            np.exp((-params[0][0]*cdist(X1**3,X2**3, metric='sqeuclidean'))**params[0][1]) +\
-            ((params[0][-1]**2)*np.eye(X1.shape[0]))# Not working
+        K = (
+            np.exp(
+                (-params[0][0] * cdist(X1, X2, metric="sqeuclidean")) ** params[0][1]
+            )
+            + np.exp(
+                (-params[0][0] * cdist(X1**2, X2**2, metric="sqeuclidean"))
+                ** params[0][1]
+            )
+            + np.exp(
+                (-params[0][0] * cdist(X1**3, X2**3, metric="sqeuclidean"))
+                ** params[0][1]
+            )
+            + ((params[0][-1] ** 2) * np.eye(X1.shape[0]))
+        )  # Not working
         if gradient:
-            dd = params[0][1] * (np.exp((-params[0][0]*cdist(X1 , X2, metric='sqeuclidean'))**(params[0][1]-1)) +\
-            np.exp((-params[0][0] *cdist(X1**2 , X2**2, metric='sqeuclidean'))**(params[0][1]-1)) + \
-                np.exp((-params[0][0]*cdist(X1**3 , X2**3, metric='sqeuclidean'))**(params[0][1]-1)))
-            gradients = [-np.multiply(cdist(X1 , X2, metric='sqeuclidean'),dd),
-                         -np.multiply(cdist(X1**2 , X2**2, metric='sqeuclidean'),dd),
-                         -np.multiply(cdist(X1**3 , X2**3, metric='sqeuclidean'),dd), dd,
-                         2*params[0][-1]*np.eye(X1.shape[0])]
+            dd = params[0][1] * (
+                np.exp(
+                    (-params[0][0] * cdist(X1, X2, metric="sqeuclidean"))
+                    ** (params[0][1] - 1)
+                )
+                + np.exp(
+                    (-params[0][0] * cdist(X1**2, X2**2, metric="sqeuclidean"))
+                    ** (params[0][1] - 1)
+                )
+                + np.exp(
+                    (-params[0][0] * cdist(X1**3, X2**3, metric="sqeuclidean"))
+                    ** (params[0][1] - 1)
+                )
+            )
+            gradients = [
+                -np.multiply(cdist(X1, X2, metric="sqeuclidean"), dd),
+                -np.multiply(cdist(X1**2, X2**2, metric="sqeuclidean"), dd),
+                -np.multiply(cdist(X1**3, X2**3, metric="sqeuclidean"), dd),
+                dd,
+                2 * params[0][-1] * np.eye(X1.shape[0]),
+            ]
             return K, gradients
 
         else:
             return K
 
-    if Type == 'Sigmoid':
+    if Type == "Sigmoid":
         # This is not a positive semidefinite Kernel. Some tweaking has to be done
         # to make this work. Probably along the lines of KdotK.T
-        K = np.tanh(params[0][0]*np.dot(X1,X2.T) + params[0][1]) +\
-            ((params[0][-1]**2)*np.eye(X1.shape[0]))
+        K = np.tanh(params[0][0] * np.dot(X1, X2.T) + params[0][1]) + (
+            (params[0][-1] ** 2) * np.eye(X1.shape[0])
+        )
         if gradient:
-            sech2 = 1/(np.cosh(params[0][0]*np.dot(X1,X2.T) + params[0][1])**2)
-            gradients = [np.multiply(np.dot(X1,X2.T),sech2),sech2,
-                         2*params[0][-1]*np.eye(X1.shape[0]) ]
+            sech2 = 1 / (np.cosh(params[0][0] * np.dot(X1, X2.T) + params[0][1]) ** 2)
+            gradients = [
+                np.multiply(np.dot(X1, X2.T), sech2),
+                sech2,
+                2 * params[0][-1] * np.eye(X1.shape[0]),
+            ]
             return K, gradients
-         # This isn't working, probably some parameters for lengthscales are needed for each dimension
+        # This isn't working, probably some parameters for lengthscales are needed for each dimension
         else:
             return K
 
-    if Type == 'RQ':
+    if Type == "RQ":
         LAMBDA = np.eye(len(X1[0]))
-        length_scales = 1/params[0][1:-1]
-        np.fill_diagonal(LAMBDA,length_scales)
-        X1 = np.dot(X1,LAMBDA)
-        X2 = np.dot(X2,LAMBDA)
-        sqdist = cdist(X1 , X2, metric='sqeuclidean').T
-        K = 1 - (sqdist/(sqdist+(params[0][0])**2)) +\
-            ((params[0][-1]**2)*np.eye(X1.shape[0]))
+        length_scales = 1 / params[0][1:-1]
+        np.fill_diagonal(LAMBDA, length_scales)
+        X1 = np.dot(X1, LAMBDA)
+        X2 = np.dot(X2, LAMBDA)
+        sqdist = cdist(X1, X2, metric="sqeuclidean").T
+        K = (
+            1
+            - (sqdist / (sqdist + (params[0][0]) ** 2))
+            + ((params[0][-1] ** 2) * np.eye(X1.shape[0]))
+        )
 
         if gradient:
-            denom = 1/((sqdist+(params[0][0])**2))**2
-            g = [cdist(np.expand_dims(X1[:,i],-1),
-                       np.expand_dims(X2[:,i],-1),
-                       metric='sqeuclidean')/(params[0][i+1]) \
-                 for i in range(X1.shape[1]) ]
-            gradients = [-2*denom*g[i]*(params[0][0])**2 for i in range(X1.shape[1])]
-            gradients = [2*params[0][0]*sqdist*denom] + gradients +\
-                [2*params[0][-1]*np.eye(X1.shape[0])]
+            denom = 1 / ((sqdist + (params[0][0]) ** 2)) ** 2
+            g = [
+                cdist(
+                    np.expand_dims(X1[:, i], -1),
+                    np.expand_dims(X2[:, i], -1),
+                    metric="sqeuclidean",
+                )
+                / (params[0][i + 1])
+                for i in range(X1.shape[1])
+            ]
+            gradients = [
+                -2 * denom * g[i] * (params[0][0]) ** 2 for i in range(X1.shape[1])
+            ]
+            gradients = (
+                [2 * params[0][0] * sqdist * denom]
+                + gradients
+                + [2 * params[0][-1] * np.eye(X1.shape[0])]
+            )
             return K, gradients
 
         else:
             return K
 
-
-    if Type == 'SRQ':
+    if Type == "SRQ":
         LAMBDA = np.eye(len(X1[0]))
-        length_scales = 1/params[0][:-1]
-        np.fill_diagonal(LAMBDA,length_scales)
-        X1 = np.dot(X1,LAMBDA)
-        X2 = np.dot(X2,LAMBDA)
-        sqdist = cdist(X1 , X2, metric='sqeuclidean').T
-        return (1/(1 + (sqdist/params[0][-1])) )**params[0][-1]
+        length_scales = 1 / params[0][:-1]
+        np.fill_diagonal(LAMBDA, length_scales)
+        X1 = np.dot(X1, LAMBDA)
+        X2 = np.dot(X2, LAMBDA)
+        sqdist = cdist(X1, X2, metric="sqeuclidean").T
+        return (1 / (1 + (sqdist / params[0][-1]))) ** params[0][-1]
 
-    if Type == 'MultiQuad':
+    if Type == "MultiQuad":
         # This Kernel is not positive semidefinite so a lot of tweaking would
         # have to be done to make this work. Maybe take some product of KdotK.T
         LAMBDA = np.eye(len(X1[0]))
-        length_scales = 1/params[0][1:-1]
-        np.fill_diagonal(LAMBDA,length_scales)
-        X1 = np.dot(X1,LAMBDA)
-        X2 = np.dot(X2,LAMBDA)
-        sqdist = cdist(X1 , X2, metric='sqeuclidean').T
-        K = np.sqrt(sqdist + (params[0][0]**2)) +\
-            ((params[0][-1]**2)*np.eye(X1.shape[0]))
+        length_scales = 1 / params[0][1:-1]
+        np.fill_diagonal(LAMBDA, length_scales)
+        X1 = np.dot(X1, LAMBDA)
+        X2 = np.dot(X2, LAMBDA)
+        sqdist = cdist(X1, X2, metric="sqeuclidean").T
+        K = np.sqrt(sqdist + (params[0][0] ** 2)) + (
+            (params[0][-1] ** 2) * np.eye(X1.shape[0])
+        )
         if gradient:
-            g = [cdist(np.expand_dims(X1[:,i],-1),
-                       np.expand_dims(X2[:,i],-1),
-                       metric='sqeuclidean')/(params[0][i+1]) \
-                 for i in range(X1.shape[1]) ]
-            gradients = [np.multiply(g[i],1/K) for i in range(X1.shape[1])]
-            gradients = [params[0][0]/K] + gradients +\
-                [2*params[0][-1]*np.eye(X1.shape[0])]
+            g = [
+                cdist(
+                    np.expand_dims(X1[:, i], -1),
+                    np.expand_dims(X2[:, i], -1),
+                    metric="sqeuclidean",
+                )
+                / (params[0][i + 1])
+                for i in range(X1.shape[1])
+            ]
+            gradients = [np.multiply(g[i], 1 / K) for i in range(X1.shape[1])]
+            gradients = (
+                [params[0][0] / K]
+                + gradients
+                + [2 * params[0][-1] * np.eye(X1.shape[0])]
+            )
             return K, gradients
 
         else:
             return K
 
-    if Type == 'InvMultiQuad':
+    if Type == "InvMultiQuad":
         LAMBDA = np.eye(len(X1[0]))
-        length_scales = 1/params[0][1:-1]
-        np.fill_diagonal(LAMBDA,length_scales)
-        X1 = np.dot(X1,LAMBDA)
-        X2 = np.dot(X2,LAMBDA)
-        sqdist = np.sqrt(cdist(X1 , X2, metric='sqeuclidean').T + (params[0][0]**2))
-        K = 1/sqdist + ((params[0][-1]**2)*np.eye(X1.shape[0]))
+        length_scales = 1 / params[0][1:-1]
+        np.fill_diagonal(LAMBDA, length_scales)
+        X1 = np.dot(X1, LAMBDA)
+        X2 = np.dot(X2, LAMBDA)
+        sqdist = np.sqrt(cdist(X1, X2, metric="sqeuclidean").T + (params[0][0] ** 2))
+        K = 1 / sqdist + ((params[0][-1] ** 2) * np.eye(X1.shape[0]))
         if gradient:
-            g = [cdist(np.expand_dims(X1[:,i],-1),
-                       np.expand_dims(X2[:,i],-1),
-                       metric='sqeuclidean')/(params[0][i+1]) \
-                 for i in range(X1.shape[1]) ]
-            gradients = [-np.multiply(g[i],K**3) for i in range(X1.shape[1])]
-            gradients = [-params[0][0]*(K**3)] +  gradients +\
-                [2*params[0][-1]*np.eye(X1.shape[0])]
+            g = [
+                cdist(
+                    np.expand_dims(X1[:, i], -1),
+                    np.expand_dims(X2[:, i], -1),
+                    metric="sqeuclidean",
+                )
+                / (params[0][i + 1])
+                for i in range(X1.shape[1])
+            ]
+            gradients = [-np.multiply(g[i], K**3) for i in range(X1.shape[1])]
+            gradients = (
+                [-params[0][0] * (K**3)]
+                + gradients
+                + [2 * params[0][-1] * np.eye(X1.shape[0])]
+            )
 
             return K, gradients
         else:
             return K
-    if Type == 'Wave':
-        dist = cdist(X1 , X2, metric='euclidean')
-        K = ((params[0][0]/dist) * np.sin(dist/params[0][0])) +\
-            ((params[0][-1]**2)*np.eye(X1.shape[0]))
+    if Type == "Wave":
+        dist = cdist(X1, X2, metric="euclidean")
+        K = ((params[0][0] / dist) * np.sin(dist / params[0][0])) + (
+            (params[0][-1] ** 2) * np.eye(X1.shape[0])
+        )
         if gradient:
-            arg = dist/params[0][0]
-            gradients = (1/dist) * (np.sin(arg) - (np.cos(arg)/(params[0][0])**2)) +\
-                [2*params[0][-1]*np.eye(X1.shape[0])]
+            arg = dist / params[0][0]
+            gradients = (1 / dist) * (
+                np.sin(arg) - (np.cos(arg) / (params[0][0]) ** 2)
+            ) + [2 * params[0][-1] * np.eye(X1.shape[0])]
             return K, gradients
         else:
             return K
 
-    if Type == 'Power':
-        K = cdist(X1/params[0][1:-1],X2/params[0][1:-1], metric='euclidean')**params[0][0] +\
-            ((params[0][-1]**2)*np.eye(X1.shape[0]))
+    if Type == "Power":
+        K = cdist(
+            X1 / params[0][1:-1], X2 / params[0][1:-1], metric="euclidean"
+        ) ** params[0][0] + ((params[0][-1] ** 2) * np.eye(X1.shape[0]))
         if gradient:
-            dd = params[0][0] * cdist(X1/params[0][1:-1],X2/params[0][1:-1],
-                                      metric='euclidean')**(params[0][0]-1)
-            g = [cdist(np.expand_dims(X1[:,i]/params[0][i+1],-1),
-                       np.expand_dims(X2[:,i]/params[0][i+1],-1),
-                       metric='sqeuclidean')/(params[0][i+1]) \
-                 for i in range(X1.shape[1]) ]
-            gradients = [np.multiply(g[i],dd) for i in range(X1.shape[1])]
-            gradients = [dd] +  gradients + [2*params[0][-1]*np.eye(X1.shape[0])]
+            dd = params[0][0] * cdist(
+                X1 / params[0][1:-1], X2 / params[0][1:-1], metric="euclidean"
+            ) ** (params[0][0] - 1)
+            g = [
+                cdist(
+                    np.expand_dims(X1[:, i] / params[0][i + 1], -1),
+                    np.expand_dims(X2[:, i] / params[0][i + 1], -1),
+                    metric="sqeuclidean",
+                )
+                / (params[0][i + 1])
+                for i in range(X1.shape[1])
+            ]
+            gradients = [np.multiply(g[i], dd) for i in range(X1.shape[1])]
+            gradients = [dd] + gradients + [2 * params[0][-1] * np.eye(X1.shape[0])]
             return K, gradients
         else:
             return K
 
-    if Type == 'Log':
+    if Type == "Log":
         # This is a non positive definite Kernel
-        dist = cdist(X1 , X2, metric='euclidean').T
-        K = -np.log((dist**params[0][0]) + 1) +\
-            ((params[0][-1]**2)*np.eye(X1.shape[0]))
+        dist = cdist(X1, X2, metric="euclidean").T
+        K = -np.log((dist ** params[0][0]) + 1) + (
+            (params[0][-1] ** 2) * np.eye(X1.shape[0])
+        )
         if gradient:
-            arg = dist**params[0][0]
-            gradients = arg * np.log(dist)/ (arg+1) +\
-                [2*params[0][-1]*np.eye(X1.shape[0])]
+            arg = dist ** params[0][0]
+            gradients = arg * np.log(dist) / (arg + 1) + [
+                2 * params[0][-1] * np.eye(X1.shape[0])
+            ]
             return K, gradients
         else:
             return K
 
-    if Type == 'Cauchy':
+    if Type == "Cauchy":
         # This works very nice and fast
-        sqdist = cdist(X1 , X2, metric='sqeuclidean').T
-        K = 1/(1+(sqdist/(params[0][0]**2))) +\
-            ((params[0][-1]**2)*np.eye(X1.shape[0]))
+        sqdist = cdist(X1, X2, metric="sqeuclidean").T
+        K = 1 / (1 + (sqdist / (params[0][0] ** 2))) + (
+            (params[0][-1] ** 2) * np.eye(X1.shape[0])
+        )
         if gradient:
-            gradients = [sqdist/(((params[0][0]**2)+sqdist)**2)] +\
-                [2*params[0][-1]*np.eye(X1.shape[0])]
+            gradients = [sqdist / (((params[0][0] ** 2) + sqdist) ** 2)] + [
+                2 * params[0][-1] * np.eye(X1.shape[0])
+            ]
             return K, gradients
         else:
             return K
 
-    if Type == 'Tstudent':
+    if Type == "Tstudent":
         # This isn't working at the moment
         LAMBDA = np.eye(len(X1[0]))
-        length_scales = 1/params[0][1:]
-        np.fill_diagonal(LAMBDA,length_scales)
-        X1 = np.dot(X1,LAMBDA)
-        X2 = np.dot(X2,LAMBDA)
-        sqdist = cdist(X1 , X2, metric='euclidean').T
-        K = 1/(1+(sqdist**params[0][0])) +\
-            ((params[0][-1]**2)*np.eye(X1.shape[0]))
+        length_scales = 1 / params[0][1:]
+        np.fill_diagonal(LAMBDA, length_scales)
+        X1 = np.dot(X1, LAMBDA)
+        X2 = np.dot(X2, LAMBDA)
+        sqdist = cdist(X1, X2, metric="euclidean").T
+        K = 1 / (1 + (sqdist ** params[0][0])) + (
+            (params[0][-1] ** 2) * np.eye(X1.shape[0])
+        )
         if gradient:
-            da = -(sqdist**params[0][0])*np.log(sqdist)*(K**2)
-            arg = (sqdist**(params[0][0]-2))*(K**2)
-            gradients =  [da] + [params[0][0]*np.multiply(
-                cdist(np.expand_dims(X1[:,i],-1),
-                       np.expand_dims(X2[:,i],-1),
-                       metric='sqeuclidean')/(params[0][i+1]),arg)
-                                 for i in range(X1.shape[1])] +\
-                [2*params[0][-1]*np.eye(X1.shape[0])]
+            da = -(sqdist ** params[0][0]) * np.log(sqdist) * (K**2)
+            arg = (sqdist ** (params[0][0] - 2)) * (K**2)
+            gradients = (
+                [da]
+                + [
+                    params[0][0]
+                    * np.multiply(
+                        cdist(
+                            np.expand_dims(X1[:, i], -1),
+                            np.expand_dims(X2[:, i], -1),
+                            metric="sqeuclidean",
+                        )
+                        / (params[0][i + 1]),
+                        arg,
+                    )
+                    for i in range(X1.shape[1])
+                ]
+                + [2 * params[0][-1] * np.eye(X1.shape[0])]
+            )
             return K, gradients
         else:
             return K
-

--- a/spentfuelgpr/spentfuelgpr/predict_posterior.py
+++ b/spentfuelgpr/spentfuelgpr/predict_posterior.py
@@ -11,13 +11,15 @@ import os
 from . import kernel
 
 
-#TODO
+# TODO
 # - Find a workaround for the ugly calculations that are currently
 #   performed in 'get_input_params' for the 'power_output' parameter
 #   and that are only relevant (?) for the SRS reactor.
 
+
 def main():
     return
+
 
 def predict(uid_fname=""):
     """Calculate the spent fuel composition."""
@@ -28,10 +30,28 @@ def predict(uid_fname=""):
     # - decay into 'interesting' material (relevant for U->Np->Pu)
     # - stable Pu isotopes
 
-    isotopes = ('U232', 'U233', 'U234', 'U235', 'U235m', 'U236', 'U238',
-                'U239', 'U240', 'Pu238', 'Pu239', 'Pu240', 'Pu241',
-                'Pu242', 'Pu243', 'Pu244', 'Np239', 'Np240', 'Np240m',
-                'Np241')
+    isotopes = (
+        "U232",
+        "U233",
+        "U234",
+        "U235",
+        "U235m",
+        "U236",
+        "U238",
+        "U239",
+        "U240",
+        "Pu238",
+        "Pu239",
+        "Pu240",
+        "Pu241",
+        "Pu242",
+        "Pu243",
+        "Pu244",
+        "Np239",
+        "Np240",
+        "Np240m",
+        "Np241",
+    )
 
     # Check if the needed kernels and parameter information exist.
     data_dir = os.path.join(os.path.split(__file__)[0], "..", "data")
@@ -50,19 +70,20 @@ def predict(uid_fname=""):
             raise FileNotFoundError(msg)
 
     # Load input parameters, training data and the kernel type.
-    training_data = np.load(os.path.join(data_dir, "x_trainingset.npy"),
-                            allow_pickle=True)
-    if not os.path.isfile(os.path.join(data_dir,
-                                   "y_trainingset_reduced.npy")):
-        y_data = np.load(os.path.join(data_dir, "y_trainingset.npy"),
-                         allow_pickle=True).item()
+    training_data = np.load(
+        os.path.join(data_dir, "x_trainingset.npy"), allow_pickle=True
+    )
+    if not os.path.isfile(os.path.join(data_dir, "y_trainingset_reduced.npy")):
+        y_data = np.load(
+            os.path.join(data_dir, "y_trainingset.npy"), allow_pickle=True
+        ).item()
         shrink_dictionary(
-            y_data, isotopes,
-            os.path.join(data_dir, "y_trainingset_reduced.npy"))
+            y_data, isotopes, os.path.join(data_dir, "y_trainingset_reduced.npy")
+        )
 
     y_data = np.load(
-        os.path.join(data_dir, "y_trainingset_reduced.npy"),
-        allow_pickle=True).item()
+        os.path.join(data_dir, "y_trainingset_reduced.npy"), allow_pickle=True
+    ).item()
     par = ("enrichment", "temperature", "power_output", "burnup")
     reactor_input_params = get_input_params(par, uid_fname)
     reactor_input_params = np.expand_dims(reactor_input_params, axis=0)
@@ -71,8 +92,7 @@ def predict(uid_fname=""):
     spent_fuel_composition = {"spent_fuel_composition": {}}
     for iso in isotopes:
         kernel_fname = os.path.join(kernel_dir, f"{iso}.npy")
-        params_fname = os.path.join(kernel_dir,
-                                    f"training_params_{iso}.json")
+        params_fname = os.path.join(kernel_dir, f"training_params_{iso}.json")
         with open(params_fname, "r") as f:
             data = json.load(f)
             kernel_type = data["kernel_type"]
@@ -80,20 +100,23 @@ def predict(uid_fname=""):
         x_train = training_data[:size]
         y_train = np.array(y_data[iso])[:size]
         check_input_params(reactor_input_params, x_train)
-        trained_kernel = np.load(kernel_fname,
-                                 allow_pickle=True).item()
-        mass = run_kernel(reactor_input_params, x_train, y_train,
-                          trained_kernel, kernel_type)
+        trained_kernel = np.load(kernel_fname, allow_pickle=True).item()
+        mass = run_kernel(
+            reactor_input_params, x_train, y_train, trained_kernel, kernel_type
+        )
 
         if mass < 0:
-            msg = (f"Calculated mass of {iso} in spent fuel is {mass} "
-                   + "kg.\nHowever, the mass cannot be negative!\n"
-                   + f"Parameters used: {reactor_input_params}")
+            msg = (
+                f"Calculated mass of {iso} in spent fuel is {mass} "
+                + "kg.\nHowever, the mass cannot be negative!\n"
+                + f"Parameters used: {reactor_input_params}"
+            )
             raise RuntimeError(msg)
 
-        iso = iso[:-1]+"M" if iso[-1] == "m" else iso
+        iso = iso[:-1] + "M" if iso[-1] == "m" else iso
         spent_fuel_composition["spent_fuel_composition"][iso] = mass
     store_results(spent_fuel_composition, uid_fname)
+
 
 def check_input_params(params, training_data):
     """Check the validity of the input parameters.
@@ -103,15 +126,17 @@ def check_input_params(params, training_data):
     """
     min_vals = np.min(training_data, axis=0)
     max_vals = np.max(training_data, axis=0)
-    is_valid = (np.all(min_vals < params[0])
-                and np.all(params[0] < max_vals))
+    is_valid = np.all(min_vals < params[0]) and np.all(params[0] < max_vals)
 
     if not is_valid:
-        msg = ("[spentfuelgpr] One or more parameters exceed the bounds.\n"
-               + f"Minimum parameter values: {min_vals}\n"
-               + f"Actual parameter values:  {params[0]}\n"
-               + f"Maximum parameter values: {max_vals}")
+        msg = (
+            "[spentfuelgpr] One or more parameters exceed the bounds.\n"
+            + f"Minimum parameter values: {min_vals}\n"
+            + f"Actual parameter values:  {params[0]}\n"
+            + f"Maximum parameter values: {max_vals}"
+        )
         raise ValueError(msg)
+
 
 def shrink_dictionary(data, isotopes, fname):
     """Remove unnecessary data from dictionary to reduce runtime
@@ -133,6 +158,7 @@ def shrink_dictionary(data, isotopes, fname):
     np.save(fname, d, allow_pickle=True)
 
     return
+
 
 def get_input_params(pnames, uid_fname=""):
     """Read in the Gpr input parameters.
@@ -168,19 +194,25 @@ def get_input_params(pnames, uid_fname=""):
                 # Savannah River Site reactor. Currently, they are
                 # hardcoded but this is hopefully subject to change.
                 # TODO update this implementation
-                n_assemblies_tot = 510;
-                n_assemblies_model = 18;
-                feet_to_cm = 30.48;
-                assembly_length = 12;  # in feet
-                power = (data[param] * n_assemblies_model
-                         / n_assemblies_tot / assembly_length
-                         / feet_to_cm)
+                n_assemblies_tot = 510
+                n_assemblies_model = 18
+                feet_to_cm = 30.48
+                assembly_length = 12
+                # in feet
+                power = (
+                    data[param]
+                    * n_assemblies_model
+                    / n_assemblies_tot
+                    / assembly_length
+                    / feet_to_cm
+                )
                 power *= 1e6  # conversion MW to W
                 input_params.append(power)
             else:
                 input_params.append(data[param])
 
     return np.array(input_params)
+
 
 def store_results(composition, uid_fname=""):
     """Store the composition in a .json file.
@@ -195,8 +227,10 @@ def store_results(composition, uid_fname=""):
     with open(fname, "w") as f:
         json.dump(composition, f, indent=2)
 
-def run_kernel(reactor_input_params, x_train, y_train, trained_kernel,
-               kernel_type='ASQE'):
+
+def run_kernel(
+    reactor_input_params, x_train, y_train, trained_kernel, kernel_type="ASQE"
+):
     """Calculate the mass of one isotope in the spent fuel.
 
     Parameters
@@ -219,14 +253,15 @@ def run_kernel(reactor_input_params, x_train, y_train, trained_kernel,
         The (mean predicted) mass of the isotope in the spent fuel
         after one irradiation period.
     """
-    if (kernel_type != 'ASQE'):
+    if kernel_type != "ASQE":
         msg = "Currently, only the 'ASQE' kernel type is supported."
         raise ValueError(msg)
 
     kernel_params = trained_kernel["Params"]
     alpha = trained_kernel["alpha_"]
-    k_s = kernel.Kernel(reactor_input_params, x_train, kernel_type,
-                        kernel_params, gradient=False)
+    k_s = kernel.Kernel(
+        reactor_input_params, x_train, kernel_type, kernel_params, gradient=False
+    )
     mu_s = np.dot(k_s.T, alpha)[0]
 
     # Revert the normalisation of the output which is used during
@@ -234,6 +269,7 @@ def run_kernel(reactor_input_params, x_train, y_train, trained_kernel,
     mu_s = mu_s * np.std(y_train) + np.mean(y_train)
 
     return mu_s
+
 
 """
 Part of the spent fuel compositions obtained from SERPENT simulations
@@ -271,5 +307,5 @@ Np240m: 2.402e-10  2.402e-10
 
 """
 
-if __name__=="__main__":
+if __name__ == "__main__":
     main()

--- a/spentfuelgpr/spentfuelgpr/predict_posterior.py
+++ b/spentfuelgpr/spentfuelgpr/predict_posterior.py
@@ -29,8 +29,8 @@ def predict(uid_fname=""):
     # - stable Pu isotopes
 
     isotopes = ('U232', 'U233', 'U234', 'U235', 'U235m', 'U236', 'U238',
-                'U239', 'U240', 'Pu238', 'Pu239', 'Pu240', 'Pu241', 
-                'Pu242', 'Pu243', 'Pu244', 'Np239', 'Np240', 'Np240m', 
+                'U239', 'U240', 'Pu238', 'Pu239', 'Pu240', 'Pu241',
+                'Pu242', 'Pu243', 'Pu244', 'Np239', 'Np240', 'Np240m',
                 'Np241')
 
     # Check if the needed kernels and parameter information exist.
@@ -137,14 +137,14 @@ def shrink_dictionary(data, isotopes, fname):
 def get_input_params(pnames, uid_fname=""):
     """Read in the Gpr input parameters.
 
-    Currently, the input filename is hardcoded. Maybe this will be 
-    changed in the future but at the moment I have no idea how this 
+    Currently, the input filename is hardcoded. Maybe this will be
+    changed in the future but at the moment I have no idea how this
     could be done.
-    
+
     Parameters
     ----------
     pnames : tuple
-        The names of the parameters to be extracted from the JSON 
+        The names of the parameters to be extracted from the JSON
         file.
 
     Returns
@@ -157,7 +157,7 @@ def get_input_params(pnames, uid_fname=""):
     with open(fname, "r") as f:
         data = json.load(f)
         input_params = []
-        
+
         for param in pnames:
             param = param.lower()
             if param == "enrichment":
@@ -179,7 +179,7 @@ def get_input_params(pnames, uid_fname=""):
                 input_params.append(power)
             else:
                 input_params.append(data[param])
-    
+
     return np.array(input_params)
 
 def store_results(composition, uid_fname=""):
@@ -232,12 +232,12 @@ def run_kernel(reactor_input_params, x_train, y_train, trained_kernel,
     # Revert the normalisation of the output which is used during
     # training of the Gpr.
     mu_s = mu_s * np.std(y_train) + np.mean(y_train)
-    
+
     return mu_s
 
 """
-Part of the spent fuel compositions obtained from SERPENT simulations 
-of one Savannah River Site reactors. Taken from Max Schalz' master 
+Part of the spent fuel compositions obtained from SERPENT simulations
+of one Savannah River Site reactors. Taken from Max Schalz' master
 thesis, see https://github.com/maxschalz/studious_potato/blob/main/data/SERPENT_outputs_NatU_percentages.npy
 Simulations kindly provided by Antonio Figueroa.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@ USE_CYCLUS("misoenrichment" "enrichment_calculator")
 USE_CYCLUS("misoenrichment" "miso_helper")
 USE_CYCLUS("misoenrichment" "flexible_input")
 
-USE_CYCLUS("misoenrichment" "gpr_reactor")
+#USE_CYCLUS("misoenrichment" "gpr_reactor")
 
 INSTALL_CYCLUS_MODULE("misoenrichment" "./")
 

--- a/src/enrichment_calculator.cc
+++ b/src/enrichment_calculator.cc
@@ -20,20 +20,20 @@ EnrichmentCalculator::EnrichmentCalculator() : EnrichmentCalculator(1.4) {}
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Constructor delegation only possible from C++11 onwards, CMake checks if
 // C++11 is supported.
-EnrichmentCalculator::EnrichmentCalculator(double gamma_235) : 
-  EnrichmentCalculator(misotest::comp_reprocessedU(), 0.05, 0.003, 
+EnrichmentCalculator::EnrichmentCalculator(double gamma_235) :
+  EnrichmentCalculator(misotest::comp_reprocessedU(), 0.05, 0.003,
                        gamma_235, 1, 1, 1e299, true) {}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 EnrichmentCalculator::EnrichmentCalculator(
     cyclus::Composition::Ptr feed_comp,
-    double target_product_assay, double target_tails_assay, 
-    double gamma_235, double feed_qty, double product_qty, 
-    double max_swu, bool use_downblending) : 
+    double target_product_assay, double target_tails_assay,
+    double gamma_235, double feed_qty, double product_qty,
+    double max_swu, bool use_downblending) :
       feed_composition(feed_comp->atom()),
       target_product_assay(target_product_assay),
       target_tails_assay(target_tails_assay),
-      gamma_235(gamma_235), 
+      gamma_235(gamma_235),
       target_feed_qty(feed_qty),
       target_product_qty(product_qty),
       feed_qty(0.), product_qty(0.),
@@ -41,7 +41,7 @@ EnrichmentCalculator::EnrichmentCalculator(
       use_downblending(use_downblending),
       isotopes(IsotopesNucID()) {
   if (feed_qty==1e299 && product_qty==1e299 && max_swu==1e299) {
-    // TODO think about whether one or two of these variables have to be 
+    // TODO think about whether one or two of these variables have to be
     // defined. Additionally, add an exception that should be thrown.
   }
   cyclus::compmath::Normalize(&feed_composition);
@@ -52,8 +52,8 @@ EnrichmentCalculator::EnrichmentCalculator(
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 EnrichmentCalculator::EnrichmentCalculator(const EnrichmentCalculator& e) :
-    feed_composition(e.feed_composition), 
-    product_composition(e.product_composition), 
+    feed_composition(e.feed_composition),
+    product_composition(e.product_composition),
     tails_composition(e.tails_composition),
     target_product_assay(e.target_product_assay),
     target_tails_assay(e.target_tails_assay),
@@ -71,29 +71,29 @@ void EnrichmentCalculator::CalculateGammaAlphaStar_() {
   for (int i : isotopes) {
     // E. von Halle Eq. (15)
     alpha_star[i] = separation_factors[i]
-                    / std::sqrt(separation_factors[IsotopeToNucID(235)]); 
+                    / std::sqrt(separation_factors[IsotopeToNucID(235)]);
   }
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 EnrichmentCalculator& EnrichmentCalculator::operator= (
     const EnrichmentCalculator& e) {
-  
+
   feed_composition = e.feed_composition;
   product_composition = e.product_composition;
   tails_composition = e.tails_composition;
 
   target_product_assay = e.target_product_assay;
-  target_tails_assay = e.target_tails_assay;  
+  target_tails_assay = e.target_tails_assay;
   target_feed_qty = e.target_feed_qty;
   target_product_qty = e.target_product_qty;
   max_swu = e.max_swu;  // in kg SWU month^-1
 
   use_downblending = e.use_downblending;
-  
+
   gamma_235 = e.gamma_235;
   CalculateGammaAlphaStar_();
-  
+
   // TODO Check why the recalculated variables are not copied
   BuildMatchedAbundanceRatioCascade();
 
@@ -122,7 +122,7 @@ void EnrichmentCalculator::PPrint() {
             << "  Isotope         Feed     Product       Tails\n";
   for (int nuc : isotopes) {
     printf("      %3d   %10.4e  %10.4e  %10.4e\n", NucIDToIsotope(nuc),
-        feed_composition[nuc], product_composition[nuc], 
+        feed_composition[nuc], product_composition[nuc],
         tails_composition[nuc]);
   }
 }
@@ -130,13 +130,13 @@ void EnrichmentCalculator::PPrint() {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void EnrichmentCalculator::SetInput(
     cyclus::Composition::Ptr new_feed_composition,
-    double new_target_product_assay, double new_target_tails_assay, 
+    double new_target_product_assay, double new_target_tails_assay,
     double new_feed_qty, double new_product_qty, double new_max_swu,
     double new_gamma_235, bool new_use_downblending) {
-  
+
   feed_composition = new_feed_composition->atom();
   cyclus::compmath::Normalize(&feed_composition);
-  
+
   if (new_gamma_235 != gamma_235) {
     gamma_235 = new_gamma_235;
     CalculateGammaAlphaStar_();
@@ -147,7 +147,7 @@ void EnrichmentCalculator::SetInput(
   target_feed_qty = new_feed_qty;
   target_product_qty = new_product_qty;
   max_swu = new_max_swu;
-  
+
   use_downblending = new_use_downblending;
 
   // TODO Think about reimplementing this part to ensure that only the bare
@@ -155,7 +155,7 @@ void EnrichmentCalculator::SetInput(
   /*
   // If any of the concentrations change, then redesign the cascade from
   // scratch.
-  if (!cyclus::compmath::AlmostEq(new_compmap, feed_composition, 
+  if (!cyclus::compmath::AlmostEq(new_compmap, feed_composition,
                                   kEpsCompMap)
       || !cyclus::AlmostEq(new_target_product_assay, target_product_assay)
       || !cyclus::AlmostEq(new_target_tails_assay, target_tails_assay)) {
@@ -166,23 +166,23 @@ void EnrichmentCalculator::SetInput(
     target_feed_qty = new_feed_qty;
     target_product_qty = new_product_qty;
     max_swu = new_max_swu;
-    
+
     BuildMatchedAbundanceRatioCascade();
-  } else if (!cyclus::AlmostEq(new_feed_qty, target_feed_qty) 
+  } else if (!cyclus::AlmostEq(new_feed_qty, target_feed_qty)
       || !cyclus::AlmostEq(new_product_qty, target_product_qty)
       || !cyclus::AlmostEq(new_max_swu, max_swu)) {
     target_feed_qty = new_feed_qty;
     target_product_qty = new_product_qty;
     max_swu = new_max_swu;
-    
+
     if (feed_qty==1e299 && product_qty==1e299 && max_swu==1e299) {
       // TODO think about whether one or two of these variables have to be
       // defined. Additionally, add an exception that should be thrown.
     }
     CalculateFlows_();
-    
+
     // if this code snippet is used again then add downblending!!
-  
+
   }
   */
   BuildMatchedAbundanceRatioCascade();
@@ -191,11 +191,11 @@ void EnrichmentCalculator::SetInput(
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void EnrichmentCalculator::EnrichmentOutput(
     cyclus::Composition::Ptr& product_comp, cyclus::Composition::Ptr& tails_comp,
-    double& feed_used, double& swu_used, double& product_produced, 
+    double& feed_used, double& swu_used, double& product_produced,
     double& tails_produced, int& n_enrich, int& n_strip) {
 
-  // This step is needed to prevent a 'double free' error. It is caused for 
-  // unknown reasons by cyclus::Material::ExtractComp and 
+  // This step is needed to prevent a 'double free' error. It is caused for
+  // unknown reasons by cyclus::Material::ExtractComp and
   // cyclus::compmath::ApplyThreshold. See also Cyclus issue #1524:
   // https://github.com/cyclus/cyclus/issues/1524
   cyclus::CompMap cm;
@@ -206,12 +206,12 @@ void EnrichmentCalculator::EnrichmentOutput(
   }
   product_comp = cyclus::Composition::CreateFromAtom(cm);
   tails_comp = cyclus::Composition::CreateFromAtom(tails_composition);
-  
+
   feed_used = feed_qty;
   swu_used = swu;
   product_produced = product_qty;
   tails_produced = tails_qty;
-  
+
   n_enrich = n_enriching;
   n_strip = n_stripping;
 }
@@ -227,7 +227,7 @@ void EnrichmentCalculator::ProductOutput(
 void EnrichmentCalculator::BuildMatchedAbundanceRatioCascade() {
   CalculateNStages_();
   CalculateFlows_();
-  
+
   if (use_downblending) {
     Downblend_();
   }
@@ -236,10 +236,10 @@ void EnrichmentCalculator::BuildMatchedAbundanceRatioCascade() {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void EnrichmentCalculator::CalculateNStages_() {
   // The target concentrations should always be reached or exceeded (i.e.,
-  // at least equal U235 concentration in product, at most equal 
+  // at least equal U235 concentration in product, at most equal
   // U235 concentration in tails).
   n_enriching = 0;
-  n_stripping = 0; 
+  n_stripping = 0;
   do {
     n_enriching++;
     CalculateConcentrations_();
@@ -263,31 +263,31 @@ void EnrichmentCalculator::CalculateFlows_() {
   CalculateSums(sum_e, sum_s);
 
   // In the following, it is determined if the feed or the product quantity
-  // available is a constraint. For this, the target feed and product 
+  // available is a constraint. For this, the target feed and product
   // quantities are used and then it is compared which of both streams is
   // the constraining factor.
   feed_qty = target_product_qty / sum_e;  // Eq. (47)
   product_qty = target_feed_qty * sum_e;  // Eq. (47)
-  
+
   // If we produce less product than desired then the feed is contraining.
   bool feed_is_constraint = product_qty < target_product_qty;
   product_qty = feed_is_constraint ? product_qty : target_product_qty;
   feed_qty = feed_is_constraint ? target_feed_qty : feed_qty;
   tails_qty = feed_qty * sum_s;  // Eq. (50)
-  
+
   // Having determined the enrichment flows, calculate the separative work
   // that is performed and check if it does not exceed the SWU capacity.
   // If it does, recalculate using the given SWU capacity.
   CalculateSwu_();
   if (swu > max_swu) {
     swu = max_swu;
-    
+
     feed_qty = swu / (ValueFunction_(product_composition)*sum_e
                       + ValueFunction_(tails_composition)*sum_s
                       - ValueFunction_(feed_composition));
     product_qty = feed_qty * sum_e;
     tails_qty = feed_qty * sum_s;
-  } 
+  }
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -305,7 +305,7 @@ double EnrichmentCalculator::ValueFunction_(
   const int NUCID_235 = IsotopeToNucID(235);
   const int NUCID_238 = IsotopeToNucID(238);
   double value = 0.;
-  
+
   try {
     composition.at(NUCID_235);
     composition.at(NUCID_238);
@@ -330,9 +330,9 @@ double EnrichmentCalculator::ValueFunction_(
     double k = (separation_factors[i]-1)
                / (separation_factors[NUCID_235]-1);
     if (cyclus::AlmostEq(k, 0.5)) {
-      // This formula is not included in  de la Garza 1963, it is taken 
+      // This formula is not included in  de la Garza 1963, it is taken
       // from the preceding article, see Eq. (26) in:
-      // A. de la Garza et al., 'Multicomponent isotope separation in 
+      // A. de la Garza et al., 'Multicomponent isotope separation in
       // cascades'. Chemical Engineering Science 15, pp. 188-209 (1961).
       value += std::log(composition.at(i) / composition.at(NUCID_238));
     } else {
@@ -352,17 +352,17 @@ void EnrichmentCalculator::CalculateConcentrations_() {
   std::map<int,double> s;
   for (int i : isotopes) {
     // Eq. (37)
-    e[i] = 1. / alpha_star[i] 
+    e[i] = 1. / alpha_star[i]
            / (1.-std::pow(alpha_star[i],-n_enriching));
     // Eq. (39)
-    s[i] = 1. / alpha_star[i] 
+    s[i] = 1. / alpha_star[i]
            / (std::pow(alpha_star[i], n_stripping+1.)-1.);
   }
 
   double sum_e;
   double sum_s;
   CalculateSums(sum_e, sum_s);
-  
+
   // Calculate the compositions of product and tails.
   for (int i : isotopes) {
     double atom_frac = MIsoFrac(feed_composition, i);
@@ -375,11 +375,11 @@ void EnrichmentCalculator::CalculateConcentrations_() {
 void EnrichmentCalculator::Downblend_() {
   double feed_assay = MIsoAssay(feed_composition);
   double product_assay = MIsoAssay(product_composition);
-  
+
   if (product_assay - target_product_assay < 0.00005) {
     return;
   }
-  
+
   // Both const values store the initial value passed by MIsoEnrich while
   // the non-const target quantities are used to calculate the amount of
   // feed and product material for enrichment (excluding downblending).
@@ -390,7 +390,7 @@ void EnrichmentCalculator::Downblend_() {
   double blend_feed_per_product = (product_assay-target_product_assay)
                                   / (target_product_assay-feed_assay);
 
-  // Check whether product or feed is the constraining factor and adapt 
+  // Check whether product or feed is the constraining factor and adapt
   // the corresponding quantity.
   if (cyclus::AlmostEq(product_qty, TARGET_PRODUCT_QTY)) {
     target_product_qty /= 1 + blend_feed_per_product;
@@ -399,25 +399,25 @@ void EnrichmentCalculator::Downblend_() {
     double sum_e;
     double sum_s;
     CalculateSums(sum_e, sum_s);
-    
+
     target_feed_qty /= 1 + blend_feed_per_product*sum_e;
     CalculateFlows_();
-  } 
-  
+  }
+
   // Calculate the blending feed needed. If the SWU is the constraint or in
   // 'close-call' cases (e.g., product is the constraint but feed is nearly
   // completely used or vice-versa), check that both product and feed
   // limits are not exceeded.
   double blend_feed = blend_feed_per_product * product_qty;
-  if (blend_feed+feed_qty > TARGET_FEED_QTY 
+  if (blend_feed+feed_qty > TARGET_FEED_QTY
       && !cyclus::AlmostEq(blend_feed+feed_qty, TARGET_FEED_QTY)) {
     double sum_e;
     double sum_s;
     CalculateSums(sum_e, sum_s);
-    
+
     target_feed_qty /= 1 + blend_feed_per_product*sum_e;
     CalculateFlows_();
-    
+
     blend_feed = blend_feed_per_product * product_qty;
   }
   if (blend_feed+product_qty > TARGET_PRODUCT_QTY
@@ -427,7 +427,7 @@ void EnrichmentCalculator::Downblend_() {
 
     blend_feed = blend_feed_per_product * product_qty;
   }
-  
+
   // Finalise the downblending:
   // Calculate the downblended product composition.
   for (int i : isotopes) {
@@ -438,9 +438,9 @@ void EnrichmentCalculator::Downblend_() {
   // Add blending feed to mass balances.
   feed_qty += blend_feed;
   product_qty += blend_feed;
-  
+
   return;
-} 
+}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void EnrichmentCalculator::CalculateSums(double& sum_e, double& sum_s) {
@@ -448,14 +448,14 @@ void EnrichmentCalculator::CalculateSums(double& sum_e, double& sum_s) {
   // to his article.
   sum_e = 0;
   sum_s = 0;
-  
+
   for (int i : isotopes) {
     double atom_frac = MIsoFrac(feed_composition, i);
     // Eq. (37)
-    double e = 1. / alpha_star[i] 
+    double e = 1. / alpha_star[i]
                   / (1-std::pow(alpha_star[i],-n_enriching));
     // Eq. (39)
-    double s = 1. / alpha_star[i] 
+    double s = 1. / alpha_star[i]
                   / (std::pow(alpha_star[i], n_stripping+1)-1);
     sum_e += e * atom_frac / (e+s);  // right-hand side of Eq. (47)
     sum_s += s * atom_frac / (e+s);  // right-hand side of Eq. (50)

--- a/src/enrichment_calculator.h
+++ b/src/enrichment_calculator.h
@@ -17,23 +17,23 @@ class EnrichmentCalculator {
   EnrichmentCalculator(cyclus::Composition::Ptr feed_comp,
                        double target_product_assay,
                        double target_tails_assay, double gamma,
-                       double feed_qty, double product_qty, 
+                       double feed_qty, double product_qty,
                        double max_swu, bool use_downblending=true);
   EnrichmentCalculator(const EnrichmentCalculator& e);
   EnrichmentCalculator& operator= (const EnrichmentCalculator& e);
-  
+
   void PPrint();
 
   void BuildMatchedAbundanceRatioCascade();
 
   void SetInput(cyclus::Composition::Ptr new_feed_composition,
-      double new_target_product_assay, double new_target_tails_assay, 
+      double new_target_product_assay, double new_target_tails_assay,
       double new_feed_qty, double new_product_qty, double new_max_swu,
-      double gamma_235, bool use_downblending); 
+      double gamma_235, bool use_downblending);
 
-  void EnrichmentOutput(cyclus::Composition::Ptr& product_comp, 
+  void EnrichmentOutput(cyclus::Composition::Ptr& product_comp,
                         cyclus::Composition::Ptr& tails_comp, double& feed_used,
-                        double& swu_used, double& product_produced, 
+                        double& swu_used, double& product_produced,
                         double& tails_produced, int& n_enrich, int& n_strip);
   void ProductOutput(cyclus::Composition::Ptr&, double&);
 
@@ -69,9 +69,9 @@ class EnrichmentCalculator {
   // Number of stages in the enriching and in the stripping section
   int n_enriching;
   int n_stripping;
-  
+
   double gamma_235;  // The overall separation factor for U-235
-  
+
   void CalculateGammaAlphaStar_();
   void CalculateNStages_();
   void CalculateFlows_();

--- a/src/enrichment_calculator_tests.cc
+++ b/src/enrichment_calculator_tests.cc
@@ -50,6 +50,7 @@ EnrichmentCalculatorTest::EnrichmentCalculatorTest() :
     expect_n_enriching(56),
     expect_n_stripping(14) {
   bool use_downblending = false;
+  bool use_integer_stages = true;
   double target_product_assay = 0.9;
   double target_tails_assay = 0.001;
   double gamma = 1.3;
@@ -60,7 +61,7 @@ EnrichmentCalculatorTest::EnrichmentCalculatorTest() :
   e = EnrichmentCalculator(compPtr_nat_U(), target_product_assay,
                              target_tails_assay, gamma, target_feed_qty,
                              target_product_qty, max_swu,
-                             use_downblending);
+                             use_downblending, use_integer_stages);
   e.EnrichmentOutput(product_comp, tails_comp, feed_qty, swu_used,
                      product_qty, tails_qty, n_enriching, n_stripping);
   product_cm = product_comp->atom();
@@ -77,7 +78,7 @@ TEST_F(EnrichmentCalculatorTest, AssignmentOperator) {
 
   cyclus::Composition::Ptr product_comp2, tails_comp2;
   double feed_qty2, product_qty2, tails_qty2, swu_used2;
-  int n_enriching2, n_stripping2;
+  double n_enriching2, n_stripping2;
 
   e2.EnrichmentOutput(product_comp2, tails_comp2, feed_qty2, swu_used2,
                       product_qty2, tails_qty2, n_enriching2, n_stripping2);
@@ -94,8 +95,8 @@ TEST_F(EnrichmentCalculatorTest, AssignmentOperator) {
   EXPECT_DOUBLE_EQ(product_qty2, product_qty);
   EXPECT_DOUBLE_EQ(tails_qty2, tails_qty);
   EXPECT_DOUBLE_EQ(swu_used2, swu_used);
-  EXPECT_EQ(n_enriching2, n_enriching);
-  EXPECT_EQ(n_stripping2, n_stripping);
+  EXPECT_DOUBLE_EQ(n_enriching2, n_enriching);
+  EXPECT_DOUBLE_EQ(n_stripping2, n_stripping);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -119,8 +120,8 @@ TEST_F(EnrichmentCalculatorTest, Swu) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(EnrichmentCalculatorTest, NumberStages) {
-  EXPECT_EQ(expect_n_enriching, n_enriching);
-  EXPECT_EQ(expect_n_stripping, n_stripping);
+  EXPECT_DOUBLE_EQ(expect_n_enriching, n_enriching);
+  EXPECT_DOUBLE_EQ(expect_n_stripping, n_stripping);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -131,14 +132,14 @@ TEST_F(EnrichmentCalculatorTest, Downblending) {
   cyclus::Composition::Ptr bl_product_comp2;
   double bl_feed_qty, bl_product_qty, bl_tails_qty, bl_swu_used;
   double bl_feed_qty2, bl_product_qty2;
-  int dummy_int;
+  double dummy_double;
 
   // In this case, the feed is the constraining factor.
   EnrichmentCalculator blender(compPtr_nat_U(), target_product_assay,
                                0.001, 1.3, 100, 1e299, 1e299, true);
   blender.EnrichmentOutput(bl_product_comp, bl_tails_comp, bl_feed_qty,
                            bl_swu_used, bl_product_qty, bl_tails_qty,
-                           dummy_int, dummy_int);
+                           dummy_double, dummy_double);
 
   EXPECT_DOUBLE_EQ(target_product_assay, MIsoAtomAssay(bl_product_comp));
   EXPECT_DOUBLE_EQ(expect_feed_qty, bl_feed_qty);
@@ -152,7 +153,7 @@ TEST_F(EnrichmentCalculatorTest, Downblending) {
                                 1e299, true);
   blender2.EnrichmentOutput(bl_product_comp2, bl_tails_comp, bl_feed_qty2,
                             bl_swu_used, bl_product_qty2, bl_tails_qty,
-                            dummy_int, dummy_int);
+                            dummy_double, dummy_double);
 
   EXPECT_DOUBLE_EQ(target_product_assay, MIsoAtomAssay(bl_product_comp2));
   EXPECT_DOUBLE_EQ(bl_feed_qty, bl_feed_qty2);

--- a/src/enrichment_calculator_tests.cc
+++ b/src/enrichment_calculator_tests.cc
@@ -41,10 +41,10 @@ cyclus::CompMap depleted_U() {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 EnrichmentCalculatorTest::EnrichmentCalculatorTest() :
-    expect_product_comp(weapons_grade_U()), 
-    expect_tails_comp(depleted_U()), 
+    expect_product_comp(weapons_grade_U()),
+    expect_tails_comp(depleted_U()),
     expect_feed_qty(100),
-    expect_product_qty(0.67202), 
+    expect_product_qty(0.67202),
     expect_tails_qty(99.32798),
     expect_swu_used(199.17105),
     expect_n_enriching(56),
@@ -57,11 +57,11 @@ EnrichmentCalculatorTest::EnrichmentCalculatorTest() :
   double target_product_qty = 1e299;
   double max_swu = 1e299;
 
-  e = EnrichmentCalculator(compPtr_nat_U(), target_product_assay, 
+  e = EnrichmentCalculator(compPtr_nat_U(), target_product_assay,
                              target_tails_assay, gamma, target_feed_qty,
-                             target_product_qty, max_swu, 
+                             target_product_qty, max_swu,
                              use_downblending);
-  e.EnrichmentOutput(product_comp, tails_comp, feed_qty, swu_used, 
+  e.EnrichmentOutput(product_comp, tails_comp, feed_qty, swu_used,
                      product_qty, tails_qty, n_enriching, n_stripping);
   product_cm = product_comp->atom();
   tails_cm = tails_comp->atom();
@@ -78,17 +78,17 @@ TEST_F(EnrichmentCalculatorTest, AssignmentOperator) {
   cyclus::Composition::Ptr product_comp2, tails_comp2;
   double feed_qty2, product_qty2, tails_qty2, swu_used2;
   int n_enriching2, n_stripping2;
-  
-  e2.EnrichmentOutput(product_comp2, tails_comp2, feed_qty2, swu_used2, 
+
+  e2.EnrichmentOutput(product_comp2, tails_comp2, feed_qty2, swu_used2,
                       product_qty2, tails_qty2, n_enriching2, n_stripping2);
-  
-  // This test does not strictly check the correct working of the 
+
+  // This test does not strictly check the correct working of the
   // assignment operator, but it does check the results. It is expected
-  // that if the assignment should not have worked correctly then the 
+  // that if the assignment should not have worked correctly then the
   // results would be wrong as well.
-  EXPECT_TRUE(misotest::CompareCompMap(product_comp2->atom(), 
+  EXPECT_TRUE(misotest::CompareCompMap(product_comp2->atom(),
                                        product_comp->atom()));
-  EXPECT_TRUE(misotest::CompareCompMap(tails_comp2->atom(), 
+  EXPECT_TRUE(misotest::CompareCompMap(tails_comp2->atom(),
                                        tails_comp->atom()));
   EXPECT_DOUBLE_EQ(feed_qty2, feed_qty);
   EXPECT_DOUBLE_EQ(product_qty2, product_qty);
@@ -100,7 +100,7 @@ TEST_F(EnrichmentCalculatorTest, AssignmentOperator) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(EnrichmentCalculatorTest, Concentrations) {
-  EXPECT_TRUE(misotest::CompareCompMap(expect_product_comp, 
+  EXPECT_TRUE(misotest::CompareCompMap(expect_product_comp,
                                         product_cm));
   EXPECT_TRUE(misotest::CompareCompMap(expect_tails_comp, tails_cm));
 }
@@ -132,25 +132,25 @@ TEST_F(EnrichmentCalculatorTest, Downblending) {
   double bl_feed_qty, bl_product_qty, bl_tails_qty, bl_swu_used;
   double bl_feed_qty2, bl_product_qty2;
   int dummy_int;
-  
+
   // In this case, the feed is the constraining factor.
-  EnrichmentCalculator blender(compPtr_nat_U(), target_product_assay, 
+  EnrichmentCalculator blender(compPtr_nat_U(), target_product_assay,
                                0.001, 1.3, 100, 1e299, 1e299, true);
-  blender.EnrichmentOutput(bl_product_comp, bl_tails_comp, bl_feed_qty, 
+  blender.EnrichmentOutput(bl_product_comp, bl_tails_comp, bl_feed_qty,
                            bl_swu_used, bl_product_qty, bl_tails_qty,
                            dummy_int, dummy_int);
 
   EXPECT_DOUBLE_EQ(target_product_assay, MIsoAtomAssay(bl_product_comp));
   EXPECT_DOUBLE_EQ(expect_feed_qty, bl_feed_qty);
   EXPECT_TRUE(bl_product_qty > expect_product_qty);
-  
+
   // In this case, the product is the constraining factor.
   // Of course, the results from this and from the previous enrichment
   // should be identical.
   EnrichmentCalculator blender2(compPtr_nat_U(), target_product_assay,
                                 0.001, 1.3, 1e299, bl_product_qty,
                                 1e299, true);
-  blender2.EnrichmentOutput(bl_product_comp2, bl_tails_comp, bl_feed_qty2, 
+  blender2.EnrichmentOutput(bl_product_comp2, bl_tails_comp, bl_feed_qty2,
                             bl_swu_used, bl_product_qty2, bl_tails_qty,
                             dummy_int, dummy_int);
 

--- a/src/enrichment_calculator_tests.h
+++ b/src/enrichment_calculator_tests.h
@@ -26,13 +26,13 @@ class EnrichmentCalculatorTest : public ::testing::Test {
   cyclus::Composition::Ptr product_comp, tails_comp;
   cyclus::CompMap product_cm, tails_cm;
   double feed_qty, product_qty, tails_qty, swu_used;
-  int n_enriching, n_stripping;
+  double n_enriching, n_stripping;
 
   const cyclus::CompMap expect_product_comp;
   const cyclus::CompMap expect_tails_comp;
 
-  const int expect_n_enriching;
-  const int expect_n_stripping;
+  const double expect_n_enriching;
+  const double expect_n_stripping;
 
   const double expect_feed_qty;
   const double expect_product_qty;

--- a/src/enrichment_calculator_tests.h
+++ b/src/enrichment_calculator_tests.h
@@ -21,7 +21,7 @@ class EnrichmentCalculatorTest : public ::testing::Test {
   EnrichmentCalculatorTest();
 
   EnrichmentCalculator e;
-  
+
   // Values to be calculated by EnrichmentCalculator
   cyclus::Composition::Ptr product_comp, tails_comp;
   cyclus::CompMap product_cm, tails_cm;
@@ -30,15 +30,15 @@ class EnrichmentCalculatorTest : public ::testing::Test {
 
   const cyclus::CompMap expect_product_comp;
   const cyclus::CompMap expect_tails_comp;
-  
+
   const int expect_n_enriching;
   const int expect_n_stripping;
-  
+
   const double expect_feed_qty;
   const double expect_product_qty;
   const double expect_tails_qty;
   const double expect_swu_used;
-  
+
 };
 
 }  // namespace misoenrichment

--- a/src/flexible_input.cc
+++ b/src/flexible_input.cc
@@ -14,7 +14,7 @@ FlexibleInput<T>::FlexibleInput() {;}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 template <class T>
-FlexibleInput<T>::FlexibleInput(cyclus::Agent* parent, 
+FlexibleInput<T>::FlexibleInput(cyclus::Agent* parent,
                                 std::vector<T> value) {
   value_ = value;
   time_.reserve(value.size());
@@ -28,7 +28,7 @@ FlexibleInput<T>::FlexibleInput(cyclus::Agent* parent,
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 template <class T>
 FlexibleInput<T>::FlexibleInput(cyclus::Agent* parent,
-                                std::vector<T> value, 
+                                std::vector<T> value,
                                 std::vector<int> time) {
   value_ = value;
   time_ = time;
@@ -39,12 +39,12 @@ FlexibleInput<T>::FlexibleInput(cyclus::Agent* parent,
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 template <class T>
 T FlexibleInput<T>::UpdateValue(cyclus::Agent* parent) {
-  // Get current time with t = 0 being the entrance of parent in the 
+  // Get current time with t = 0 being the entrance of parent in the
   // simulation.
   int t = parent->context()->time() - parent->enter_time();
 
   // The second conditional takes the ending of the time vector into
-  // account. If the last element is reached, *(time_it_+1) is not 
+  // account. If the last element is reached, *(time_it_+1) is not
   // evaluated.
   if (t >= *time_it_ && (time_it_+1 == time_.end() || t < *(time_it_+1))) {
     return value_[time_it_ - time_.begin()];
@@ -53,19 +53,19 @@ T FlexibleInput<T>::UpdateValue(cyclus::Agent* parent) {
     return value_[time_it_ - time_.begin()];
   } else {
     std::stringstream ss;
-    ss << "Agent '" << parent->prototype()  
-       << "' of spec '" << parent->spec() 
+    ss << "Agent '" << parent->prototype()
+       << "' of spec '" << parent->spec()
        << "' with enter_time '" << parent->enter_time()
-       << "' has passed the invalid timestamp '" << t << "' at time '" 
+       << "' has passed the invalid timestamp '" << t << "' at time '"
        << parent->context()->time() << "' to a FlexibleInput variable.\n";
-    
+
     throw cyclus::ValueError(ss.str());
   }
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 template <class T>
-void FlexibleInput<T>::CheckInput_(cyclus::Agent* parent, 
+void FlexibleInput<T>::CheckInput_(cyclus::Agent* parent,
                                    const std::vector<T>& value) {
   int lifetime = parent->lifetime();
   if (lifetime == -1) {
@@ -74,42 +74,42 @@ void FlexibleInput<T>::CheckInput_(cyclus::Agent* parent,
 
   if (value.size() > lifetime) {
     std::stringstream ss;
-    ss << "While initialising agent '" << parent->prototype()  
+    ss << "While initialising agent '" << parent->prototype()
        << "' of spec '" << parent->spec() << "' at time "
        << parent->context()->time() << " a problem appeared:\n"
        << "The value vector passed to FlexibleInput contains too many "
        << "elements.\n";
-    
+
    throw cyclus::ValueError(ss.str());
  }
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 template <class T>
-void FlexibleInput<T>::CheckInput_(cyclus::Agent* parent, 
+void FlexibleInput<T>::CheckInput_(cyclus::Agent* parent,
                                    const std::vector<T>& value,
                                    const std::vector<int>& time_vec) {
   CheckInput_(parent, value);
   if (value.size() != time_vec.size()) {
     std::stringstream ss;
-    ss << "While initialising agent '" << parent->prototype()  
-       << "' of spec '" << parent->spec() << "' at time '" 
+    ss << "While initialising agent '" << parent->prototype()
+       << "' of spec '" << parent->spec() << "' at time '"
        << parent->context()->time() << "' a problem appeared:\n"
        << "time and value vectors do not have the same size.\n"
        << "size of time vector: " << time_vec.size()
        << ", size of value vector: " << value.size() << "\n";
-    
+
     throw cyclus::ValueError(ss.str());
   }
 
   if (time_vec[0] != 0) {
     std::stringstream ss;
-    ss << "While initialising agent '" << parent->prototype()  
-       << "' of spec '" << parent->spec() << "' at time '" 
+    ss << "While initialising agent '" << parent->prototype()
+       << "' of spec '" << parent->spec() << "' at time '"
        << parent->context()->time() << "' a problem appeared:\n"
        << "the first element of the time vector must be '0' (initial "
        << "value).\n";
-    
+
     throw cyclus::ValueError(ss.str());
   }
 }

--- a/src/flexible_input.h
+++ b/src/flexible_input.h
@@ -12,14 +12,14 @@ class FlexibleInput {
  public:
   FlexibleInput();
   FlexibleInput(cyclus::Agent* parent, std::vector<T> value);
-  FlexibleInput(cyclus::Agent* parent, std::vector<T> value, 
+  FlexibleInput(cyclus::Agent* parent, std::vector<T> value,
                 std::vector<int> time);
 
   T UpdateValue(cyclus::Agent* parent);
 
  private:
   void CheckInput_(cyclus::Agent* parent, const std::vector<T>& value);
-  void CheckInput_(cyclus::Agent* parent, const std::vector<T>& value, 
+  void CheckInput_(cyclus::Agent* parent, const std::vector<T>& value,
                    const std::vector<int>& time);
 
   std::vector<T> value_;

--- a/src/flexible_input_tests.cc
+++ b/src/flexible_input_tests.cc
@@ -43,12 +43,12 @@ TEST_F(FlexibleInputTest, CheckSingleInput) {
 
   // OK
   EXPECT_NO_THROW(FlexibleInput<int> f(parent, vals););
-  
+
   std::vector<int> wrong_vals = vals;
   wrong_vals.push_back(10);
-  
+
   // Not OK, wrong_vals has more entries than simulation duration
-  EXPECT_THROW(FlexibleInput<int> ff(parent, wrong_vals);, 
+  EXPECT_THROW(FlexibleInput<int> ff(parent, wrong_vals);,
                cyclus::ValueError);
 }
 
@@ -66,7 +66,7 @@ TEST_F(FlexibleInputTest, CheckDoubleInput) {
 
   // OK
   EXPECT_NO_THROW(FlexibleInput<int> f(parent, vals, time););
-  
+
   vals.pop_back();
   // Not OK, vector sizes mismatch
   EXPECT_THROW(FlexibleInput<int> ff(parent, vals, time);,

--- a/src/flexible_input_tests.h
+++ b/src/flexible_input_tests.h
@@ -17,7 +17,7 @@ class FlexibleInputTest : public ::testing::Test {
  protected:
   FlexibleInputTest();
   ~FlexibleInputTest();
-  
+
   cyclus::MockSim SetUpMockSim();
   cyclus::Agent* parent;
   const int duration = 10;

--- a/src/gpr_reactor.h
+++ b/src/gpr_reactor.h
@@ -6,12 +6,12 @@
 
 #include "cyclus.h"
 
-// Future changes relating to the implementation of Antonio's GPRs are marked 
+// Future changes relating to the implementation of Antonio's GPRs are marked
 // with the following comment:
 // TODO ANTONIO GPR
 //
 // TODO list:
-// - check line 49 in .cc file. Ensure that `unique_out_commods.empty()` 
+// - check line 49 in .cc file. Ensure that `unique_out_commods.empty()`
 //   evaluates to `true`, else, the set gets not filled!
 // - no implementation of `Reactor::fuel_pref(cyclus::Material::Ptr)` because
 //   it is not used in the reactor class.
@@ -37,7 +37,7 @@ class GprReactor : public cyclus::Facility, public cyclus::toolkit::Position  {
   /// @warning The Prime Directive must have a space before it!
 
   #pragma cyclus
-  
+
   #pragma cyclus note {"doc": "A reactor facility that calculates its spent " \
                               "fuel composition using Gaussian process " \
                               "regression."}
@@ -46,9 +46,9 @@ class GprReactor : public cyclus::Facility, public cyclus::toolkit::Position  {
   std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> GetMatlBids(
       cyclus::CommodMap<cyclus::Material>::type& commod_requests);
   std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr> GetMatlRequests();
-  std::string str(); 
+  std::string str();
   void AcceptMatlTrades(
-      const std::vector<std::pair<cyclus::Trade<cyclus::Material>, 
+      const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
                                   cyclus::Material::Ptr> >& responses);
   void EnterNotify();
   void GetMatlTrades(
@@ -86,7 +86,7 @@ class GprReactor : public cyclus::Facility, public cyclus::toolkit::Position  {
            "same default value is used for all fuel requests." \
   }
   std::vector<double> fuel_prefs;
-  
+
   std::set<std::string> unique_out_commods;
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   // Core specifics
@@ -105,7 +105,7 @@ class GprReactor : public cyclus::Facility, public cyclus::toolkit::Position  {
            "one complete irradiation cycle." \
   }
   int n_assem_batch;
-  
+
   #pragma cyclus var { \
     "uitype": "range", \
     "range": [1., 1e5], \
@@ -117,7 +117,7 @@ class GprReactor : public cyclus::Facility, public cyclus::toolkit::Position  {
   double assem_size;
 
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  // Irradiation cycle parameters 
+  // Irradiation cycle parameters
   #pragma cyclus var { \
     "default": 0, \
     "doc": "If true, the archetype transmutes all assemblies upon " \
@@ -134,7 +134,7 @@ class GprReactor : public cyclus::Facility, public cyclus::toolkit::Position  {
            "process regression." \
   }
   int cycle_time;
-  
+
   #pragma cyclus var { \
     "default": 1, \
     "doc": "The duration of an entire refuelling period, i.e., the minimum " \
@@ -249,7 +249,7 @@ class GprReactor : public cyclus::Facility, public cyclus::toolkit::Position  {
   // interested in and that the GPRs calculate.
   const std::set<int> relevant_spent_fuel_comps;
 
-  // Filenames of files used to pass arguments and results between the Python 
+  // Filenames of files used to pass arguments and results between the Python
   // file and the C++ Cyclus archetype.
   std::string out_fname;
   std::string in_fname;
@@ -265,16 +265,16 @@ class GprReactor : public cyclus::Facility, public cyclus::toolkit::Position  {
     "uilabel": "Geographical latitude in degrees as a double", \
     "doc": "Latitude of the agent's geographical position. The value " \
            "should be expressed in degrees as a double." \
-  } 
+  }
   double latitude;
-  
+
   #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical longitude in degrees as a double", \
     "doc": "Longitude of the agent's geographical position. The value " \
            "should be expressed in degrees as a double." \
-  } 
-  double longitude; 
+  }
+  double longitude;
 
   bool Discharge_();
   bool Retired_();

--- a/src/gpr_reactor_tests.cc
+++ b/src/gpr_reactor_tests.cc
@@ -238,7 +238,7 @@ TEST_F(GprReactorTest, SpentFuelWaste) {
   valid_cm[10010000] = 1.;
   cyclus::compmath::Normalize(&valid_cm);
   EXPECT_TRUE(cyclus::compmath::AlmostEq(valid_cm, return_cm, kEpsCompMap));
- 
+
   std::remove(DoGetInFname().c_str());
 }
 

--- a/src/miso_enrich.cc
+++ b/src/miso_enrich.cc
@@ -31,6 +31,7 @@ MIsoEnrich::MIsoEnrich(cyclus::Context* ctx)
       latitude(0.0),
       longitude(0.0),
       coordinates(latitude, longitude),
+      use_integer_stages(true),
       use_downblending(true) {}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -255,10 +256,10 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr>
     cyclus::Composition::Ptr feed_comp = feed_inv_comp[feed_idx];
     cyclus::Converter<Material>::Ptr swu_converter(
         new SwuConverter(feed_comp, tails_assay, gamma_235,
-                         use_downblending));
+                         use_downblending, use_integer_stages));
     cyclus::Converter<Material>::Ptr feed_converter(
         new FeedConverter(feed_comp, tails_assay, gamma_235,
-                          use_downblending));
+                          use_downblending, use_integer_stages));
     CapacityConstraint<Material> swu_constraint(swu_capacity,
                                                 swu_converter);
     CapacityConstraint<Material> feed_constraint(
@@ -287,7 +288,7 @@ cyclus::Material::Ptr MIsoEnrich::Offer_(
 
   EnrichmentCalculator e(feed_inv_comp[feed_idx], product_assay,
                          tails_assay, gamma_235, feed_qty, product_qty,
-                         swu_capacity, use_downblending);
+                         swu_capacity, use_downblending, use_integer_stages);
   e.ProductOutput(product_comp, product_qty);
 
   return cyclus::Material::CreateUntracked(product_qty, product_comp);
@@ -443,7 +444,7 @@ cyclus::Material::Ptr MIsoEnrich::Enrich_(
   cyclus::Composition::Ptr product_comp;
   cyclus::Composition::Ptr tails_comp;
   double feed_required, swu_required, product_qty, tails_qty;
-  int n_enriching, n_stripping;
+  double n_enriching, n_stripping;
 
   double feed_assay = MIsoAtomAssay(feed_inv_comp[feed_idx]);
   double feed_qty = feed_inv[feed_idx].quantity();
@@ -453,7 +454,7 @@ cyclus::Material::Ptr MIsoEnrich::Enrich_(
   // performed!
   EnrichmentCalculator e(feed_inv_comp[feed_idx], product_assay,
                          tails_assay, gamma_235, feed_qty, request_qty,
-                         swu_capacity, use_downblending);
+                         swu_capacity, use_downblending, use_integer_stages);
   e.EnrichmentOutput(product_comp, tails_comp, feed_required,
                                    swu_required, product_qty, tails_qty,
                                    n_enriching, n_stripping);

--- a/src/miso_enrich.cc
+++ b/src/miso_enrich.cc
@@ -4,7 +4,7 @@
 #include <cmath>
 #include <iterator>
 #include <map>
-#include <sstream> 
+#include <sstream>
 #include <vector>
 
 #include "toolkit/timeseries.h"
@@ -48,13 +48,13 @@ std::string MIsoEnrich::str() {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void MIsoEnrich::EnterNotify() {
   using cyclus::Material;
-  
+
   cyclus::Facility::EnterNotify();
 
   if (swu_capacity_times[0]==-1) {
     swu_flexible = FlexibleInput<double>(this, swu_capacity_vals);
   } else {
-    swu_flexible = FlexibleInput<double>(this, swu_capacity_vals, 
+    swu_flexible = FlexibleInput<double>(this, swu_capacity_vals,
                                          swu_capacity_times);
   }
 
@@ -79,33 +79,33 @@ void MIsoEnrich::EnterNotify() {
 void MIsoEnrich::AddFeedMat_(cyclus::Material::Ptr mat) {
   cyclus::Composition::Ptr comp = mat->comp();
   int push_idx = ResBufIdx(feed_inv_comp, comp);
-  
-  // Either directly try pushing material to the right feed inventory or 
+
+  // Either directly try pushing material to the right feed inventory or
   // create a corresponding feed inventory and add it to the vector.
   if (push_idx != -1) {
-    LOG(cyclus::LEV_INFO5, "MIsoEn") << prototype() 
+    LOG(cyclus::LEV_INFO5, "MIsoEn") << prototype()
                                      << " is initially holding "
-                                     << feed_inv[push_idx].quantity() 
+                                     << feed_inv[push_idx].quantity()
                                      << " of feed in inventory no. "
                                      << push_idx << ".";
-    try {  
+    try {
       feed_inv[push_idx].Push(mat);
     } catch (cyclus::Error& e) {
       e.msg(Agent::InformErrorMsg(e.msg()));
     throw e;
     }
-    LOG(cyclus::LEV_INFO5, "MIsoEn") << prototype() << " added " 
-                                     << mat->quantity() << " of " 
-                                     << feed_commod 
+    LOG(cyclus::LEV_INFO5, "MIsoEn") << prototype() << " added "
+                                     << mat->quantity() << " of "
+                                     << feed_commod
                                      << " to its inventory no. " << push_idx
-                                     << " which is now holding " 
+                                     << " which is now holding "
                                      << feed_inv[push_idx].quantity();
   } else {
     LOG(cyclus::LEV_INFO5, "MIsoEn") << prototype() << " is initially"
                                      << " holding no feed of this"
                                      << " composition and creates a new"
                                      << " inventory.";
-  
+
     feed_inv.push_back(cyclus::toolkit::ResBuf<cyclus::Material>());
     feed_inv.back().capacity(max_feed_inventory);
     try {
@@ -117,13 +117,13 @@ void MIsoEnrich::AddFeedMat_(cyclus::Material::Ptr mat) {
     // '-1' because of index starting at 0
     feed_idx = std::distance(feed_inv.begin(), feed_inv.end()) - 1;
 
-    LOG(cyclus::LEV_INFO5, "MIsoEn") << prototype() << " added " 
-                                     << mat->quantity() << " of " 
-                                     << feed_commod 
+    LOG(cyclus::LEV_INFO5, "MIsoEn") << prototype() << " added "
+                                     << mat->quantity() << " of "
+                                     << feed_commod
                                      << " to its new inventory (no. "
                                      << feed_idx << ") which is "
-                                     << "now holding " 
-                                     << feed_inv[feed_idx].quantity();  
+                                     << "now holding "
+                                     << feed_inv[feed_idx].quantity();
   }
 }
 
@@ -144,26 +144,26 @@ void MIsoEnrich::Tick() {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void MIsoEnrich::Tock() {
   using cyclus::toolkit::RecordTimeSeries;
-  
+
   LOG(cyclus::LEV_INFO4, "MIsoEn") << prototype() << " used "
-                                   << intra_timestep_swu << " SWU"; 
+                                   << intra_timestep_swu << " SWU";
   RecordTimeSeries<cyclus::toolkit::ENRICH_SWU>(this, intra_timestep_swu);
-  
+
   LOG(cyclus::LEV_INFO4, "EnrFac") << prototype() << " used "
                                    << intra_timestep_feed << " feed";
-  RecordTimeSeries<cyclus::toolkit::ENRICH_FEED>(this, 
+  RecordTimeSeries<cyclus::toolkit::ENRICH_FEED>(this,
                                                  intra_timestep_feed);
-  RecordTimeSeries<double>("demand"+feed_commod, this, 
+  RecordTimeSeries<double>("demand"+feed_commod, this,
                            intra_timestep_feed);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr> 
+std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
 MIsoEnrich::GetMatlRequests() {
   using cyclus::Material;
   using cyclus::RequestPortfolio;
   using cyclus::Request;
-  
+
   std::set<RequestPortfolio<Material>::Ptr> ports;
   RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
   Material::Ptr mat = Request_();
@@ -185,7 +185,7 @@ cyclus::Material::Ptr MIsoEnrich::Request_() {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> 
+std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr>
     MIsoEnrich::GetMatlBids(
       cyclus::CommodMap<cyclus::Material>::type& out_requests) {
   using cyclus::Bid;
@@ -197,8 +197,8 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr>
   using cyclus::toolkit::RecordTimeSeries;
 
   std::set<BidPortfolio<Material>::Ptr> ports;
-  
-  RecordTimeSeries<double>("supply" + tails_commod, this, 
+
+  RecordTimeSeries<double>("supply" + tails_commod, this,
                            tails_inv.quantity());
   // TODO think about line below
   RecordTimeSeries<double>("supply" + product_commod, this,
@@ -207,11 +207,11 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr>
   // TODO check how reasonable this is. Apparently requests do not
   // feature the recipe, only the commodity.
   // TODO think about whether or not to implement multiple tails inventories
-  if ((out_requests.count(tails_commod) > 0) 
+  if ((out_requests.count(tails_commod) > 0)
       && (tails_inv.quantity() > 0)) {
     BidPortfolio<Material>::Ptr tails_port(new BidPortfolio<Material>());
-    
-    std::vector<Request<Material>*>& tails_requests = 
+
+    std::vector<Request<Material>*>& tails_requests =
       out_requests[tails_commod];
     std::vector<Request<Material>*>::iterator it;
     for (it = tails_requests.begin(); it!= tails_requests.end(); it++) {
@@ -224,7 +224,7 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr>
       }
     }
     // TODO remove tails_inv capacity constraint and replace it
-    // with multiple inventories of different compositions? 
+    // with multiple inventories of different compositions?
     CapacityConstraint<Material> tails_constraint(tails_inv.quantity());
     tails_port->AddConstraint(tails_constraint);
     LOG(cyclus::LEV_INFO5, "MIsoEn") << prototype()
@@ -232,44 +232,44 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr>
                                      << " of " << tails_inv.quantity();
     ports.insert(tails_port);
   }
-  
-  // TODO here, one idea would be to change the if-clause and to check if 
-  // any of the feed_inv's is not zero. If the current is not, then use 
+
+  // TODO here, one idea would be to change the if-clause and to check if
+  // any of the feed_inv's is not zero. If the current is not, then use
   // that one, else change
-  if ((out_requests.count(product_commod) > 0) 
+  if ((out_requests.count(product_commod) > 0)
       && (feed_inv[feed_idx].quantity() > 0)) {
     BidPortfolio<Material>::Ptr commod_port(new BidPortfolio<Material>());
 
-    std::vector<Request<Material>*>& commod_requests = 
+    std::vector<Request<Material>*>& commod_requests =
         out_requests[product_commod];
     std::vector<Request<Material>*>::iterator it;
     for (it = commod_requests.begin(); it != commod_requests.end(); it++) {
       Request<Material>* req = *it;
-      Material::Ptr req_mat = req->target(); 
+      Material::Ptr req_mat = req->target();
       if (ValidReq_(req_mat)) {
         Material::Ptr offer = Offer_(req_mat);
         commod_port->AddBid(req, offer, this);
       }
     }
-  
+
     cyclus::Composition::Ptr feed_comp = feed_inv_comp[feed_idx];
     cyclus::Converter<Material>::Ptr swu_converter(
-        new SwuConverter(feed_comp, tails_assay, gamma_235, 
+        new SwuConverter(feed_comp, tails_assay, gamma_235,
                          use_downblending));
     cyclus::Converter<Material>::Ptr feed_converter(
-        new FeedConverter(feed_comp, tails_assay, gamma_235, 
+        new FeedConverter(feed_comp, tails_assay, gamma_235,
                           use_downblending));
-    CapacityConstraint<Material> swu_constraint(swu_capacity, 
+    CapacityConstraint<Material> swu_constraint(swu_capacity,
                                                 swu_converter);
     CapacityConstraint<Material> feed_constraint(
         feed_inv[feed_idx].quantity(), feed_converter);
     commod_port->AddConstraint(swu_constraint);
     commod_port->AddConstraint(feed_constraint);
 
-    LOG(cyclus::LEV_INFO5, "MIsoEn") << prototype() 
+    LOG(cyclus::LEV_INFO5, "MIsoEn") << prototype()
                                      << " adding a SWU constraint of "
                                      << swu_constraint.capacity();
-    LOG(cyclus::LEV_INFO5, "MIsoEn") << prototype() 
+    LOG(cyclus::LEV_INFO5, "MIsoEn") << prototype()
                                      << " adding a feed constraint of "
                                      << feed_constraint.capacity();
     ports.insert(commod_port);
@@ -284,7 +284,7 @@ cyclus::Material::Ptr MIsoEnrich::Offer_(
   double feed_qty = feed_inv[feed_idx].quantity();
   double product_assay = MIsoAtomAssay(mat);
   double product_qty = mat->quantity();
- 
+
   EnrichmentCalculator e(feed_inv_comp[feed_idx], product_assay,
                          tails_assay, gamma_235, feed_qty, product_qty,
                          swu_capacity, use_downblending);
@@ -301,7 +301,7 @@ bool MIsoEnrich::ValidReq_(const cyclus::Material::Ptr& req_mat) {
   bool u_238_present = u_238 > 0;
   bool not_depleted = u_235 > tails_assay;
   bool possible_enrichment = u_235 < max_enrich;
-  
+
   return u_238_present && not_depleted && possible_enrichment;
 }
 
@@ -335,9 +335,9 @@ void MIsoEnrich::AdjustMatlPrefs(
       bids_vector.push_back(bid);
     }  // each bid
     std::sort(bids_vector.begin(), bids_vector.end(), SortBids);
-    
-    // The bids vector has already been sorted starting with lowest (or 
-    // zero) U235 content. The following loop sets the preferences for 
+
+    // The bids vector has already been sorted starting with lowest (or
+    // zero) U235 content. The following loop sets the preferences for
     // every request with 0 U235 content to -1 such that they are ignored.
     bool u_235_mass = false;
     for (int bid_i = 0; bid_i < bids_vector.size(); bid_i++) {
@@ -373,18 +373,18 @@ void MIsoEnrich::GetMatlTrades(
     double qty = it->amt;
     std::string commod_type = it->bid->request()->commodity();
     Material::Ptr response;
-    
+
     if (commod_type == tails_commod) {
-      LOG(cyclus::LEV_INFO5, "MIsoEn") << prototype() 
-                                       << " just received an order for " 
-                                       << it->amt << " of " 
+      LOG(cyclus::LEV_INFO5, "MIsoEn") << prototype()
+                                       << " just received an order for "
+                                       << it->amt << " of "
                                        << tails_commod;
       double pop_qty = std::min(qty, tails_inv.quantity());
       response = tails_inv.Pop(pop_qty, cyclus::eps_rsrc());
     } else {
-      LOG(cyclus::LEV_INFO5, "MIsoEn") << prototype() 
+      LOG(cyclus::LEV_INFO5, "MIsoEn") << prototype()
                                        << " just received an order for "
-                                       << it->amt << " of " 
+                                       << it->amt << " of "
                                        << product_commod;
       response = Enrich_(it->bid->offer(), qty);
     }
@@ -410,7 +410,7 @@ void MIsoEnrich::AcceptMatlTrades(
   using cyclus::Material;
   using cyclus::Trade;
   // see http://stackoverflow.com/questions/5181183/boostshared-ptr-and-inheritance
-  std::vector<std::pair<Trade<Material>, 
+  std::vector<std::pair<Trade<Material>,
                         Material::Ptr> >::const_iterator it;
   for (it = responses.begin(); it != responses.end(); it++) {
     AddMat_(it->second);
@@ -420,8 +420,8 @@ void MIsoEnrich::AcceptMatlTrades(
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void MIsoEnrich::AddMat_(cyclus::Material::Ptr mat) {
   cyclus::CompMap cm = mat->comp()->atom();
-  bool non_u_elem = false;  
-  
+  bool non_u_elem = false;
+
   cyclus::CompMap::const_iterator it;
   for (it = cm.begin(); it != cm.end(); it++) {
     if ((pyne::nucname::znum(it->first) != 92) && (it->second > 0)) {
@@ -448,7 +448,7 @@ cyclus::Material::Ptr MIsoEnrich::Enrich_(
   double feed_assay = MIsoAtomAssay(feed_inv_comp[feed_idx]);
   double feed_qty = feed_inv[feed_idx].quantity();
   double product_assay = MIsoAtomAssay(mat);
-  
+
   // In the following line, the enrichment is calculated but it is not yet
   // performed!
   EnrichmentCalculator e(feed_inv_comp[feed_idx], product_assay,
@@ -457,7 +457,7 @@ cyclus::Material::Ptr MIsoEnrich::Enrich_(
   e.EnrichmentOutput(product_comp, tails_comp, feed_required,
                                    swu_required, product_qty, tails_qty,
                                    n_enriching, n_stripping);
-  // Now, perform the enrichment by popping the feed and converting it to 
+  // Now, perform the enrichment by popping the feed and converting it to
   // product and tails.
   cyclus::Material::Ptr pop_mat;
   try {
@@ -470,11 +470,11 @@ cyclus::Material::Ptr MIsoEnrich::Enrich_(
   } catch (cyclus::Error& e) {
     std::stringstream ss;
     ss << " tried to remove " << feed_required << " from its feed "
-       << " inventory nr " << feed_idx << " holding " 
+       << " inventory nr " << feed_idx << " holding "
        << feed_inv[feed_idx].quantity();
     throw cyclus::ValueError(cyclus::Agent::InformErrorMsg(ss.str()));
   }
-  cyclus::Material::Ptr response = pop_mat->ExtractComp(product_qty, 
+  cyclus::Material::Ptr response = pop_mat->ExtractComp(product_qty,
                                                         product_comp);
   tails_inv.Push(pop_mat);
 
@@ -495,7 +495,7 @@ cyclus::Material::Ptr MIsoEnrich::Enrich_(
   LOG(cyclus::LEV_INFO5, "MIsoEn") << "   * Tails Assay (atomic frac): "
                                    << MIsoAtomAssay(pop_mat);
   LOG(cyclus::LEV_INFO5, "MIsoEn") << "   * SWU: " << swu_required;
-  LOG(cyclus::LEV_INFO5, "MIsoEn") << "   * Current SWU capacity: " 
+  LOG(cyclus::LEV_INFO5, "MIsoEn") << "   * Current SWU capacity: "
                                    << current_swu_capacity;
 
   return response;

--- a/src/miso_enrich.h
+++ b/src/miso_enrich.h
@@ -17,9 +17,10 @@ namespace misoenrichment {
 class SwuConverter : public cyclus::Converter<cyclus::Material> {
  public:
   SwuConverter(cyclus::Composition::Ptr feed_comp, double tails_assay,
-               double gamma_235, bool use_downblending)
+               double gamma_235, bool use_downblending, bool use_integer_stages)
       : feed_comp_(feed_comp), gamma_235_(gamma_235),
-        tails_assay_(tails_assay), use_downblending(use_downblending) {}
+        tails_assay_(tails_assay), use_downblending(use_downblending),
+        use_integer_stages(use_integer_stages) {}
 
   virtual ~SwuConverter() {}
 
@@ -31,7 +32,8 @@ class SwuConverter : public cyclus::Converter<cyclus::Material> {
     double product_qty = m->quantity();
     double product_assay = MIsoAtomAssay(m);
     EnrichmentCalculator e(feed_comp_, product_assay, tails_assay_, gamma_235_,
-                           1e299, product_qty, 1e299, use_downblending);
+                           1e299, product_qty, 1e299, use_downblending,
+                           use_integer_stages);
     double swu_used = e.SwuUsed();
 
     return swu_used;
@@ -51,6 +53,7 @@ class SwuConverter : public cyclus::Converter<cyclus::Material> {
 
  private:
   bool use_downblending;
+  bool use_integer_stages;
   cyclus::Composition::Ptr feed_comp_;
   double gamma_235_;
   double tails_assay_;
@@ -61,9 +64,11 @@ class SwuConverter : public cyclus::Converter<cyclus::Material> {
 class FeedConverter : public cyclus::Converter<cyclus::Material> {
  public:
   FeedConverter(cyclus::Composition::Ptr feed_comp, double tails_assay,
-                double gamma_235, bool use_downblending)
+                double gamma_235, bool use_downblending,
+                bool use_integer_stages)
       : feed_comp_(feed_comp), gamma_235_(gamma_235),
-        tails_assay_(tails_assay), use_downblending(use_downblending) {}
+        tails_assay_(tails_assay), use_downblending(use_downblending),
+        use_integer_stages(use_integer_stages) {}
 
   virtual ~FeedConverter() {}
 
@@ -75,7 +80,8 @@ class FeedConverter : public cyclus::Converter<cyclus::Material> {
     double product_qty = m->quantity();
     double product_assay = MIsoAtomAssay(m);
     EnrichmentCalculator e(feed_comp_, product_assay, tails_assay_, gamma_235_,
-                           1e299, product_qty, 1e299, use_downblending);
+                           1e299, product_qty, 1e299, use_downblending,
+                           use_integer_stages);
     double feed_used = e.FeedUsed();
 
     cyclus::toolkit::MatQuery mq(m);
@@ -100,6 +106,7 @@ class FeedConverter : public cyclus::Converter<cyclus::Material> {
 
  private:
   bool use_downblending;
+  bool use_integer_stages;
   cyclus::Composition::Ptr feed_comp_;
   double gamma_235_;
   double tails_assay_;
@@ -341,10 +348,23 @@ class MIsoEnrich : public cyclus::Facility,
     "uilabel": "Downblend the product to required enrichment level",  \
     "doc": "If set to true and if the enriched product exceeds the "  \
            "desired enrichment level, the product is downblended using "  \
-           "enrichment feed to match the desired level."  \
+           "enrichment feed to match the desired level. If this variable "  \
+           "is set to 'true',  then 'use_integer_stages' must be 'true', as "  \
+           "well."  \
   }
   bool use_downblending;
 
+  #pragma cyclus var {  \
+    "default": 1,  \
+    "tooltip": "Use an integer number of stages",  \
+    "uilabel": "Use an integer number of stages",  \
+    "doc": "If set to true (default), then an integer number of stages is "  \
+           "used such that the desired product assay is reached or exceeded "  \
+           "and the desired tails assay is reached or undershot. If set to "  \
+           "false, then a floating point number of stages is used such that "  \
+           "the desired product and tails assays are obtained."  \
+  }
+  bool use_integer_stages;
 };
 
 }  // namespace misoenrichment

--- a/src/miso_enrich.h
+++ b/src/miso_enrich.h
@@ -17,31 +17,31 @@ namespace misoenrichment {
 class SwuConverter : public cyclus::Converter<cyclus::Material> {
  public:
   SwuConverter(cyclus::Composition::Ptr feed_comp, double tails_assay,
-               double gamma_235, bool use_downblending) 
+               double gamma_235, bool use_downblending)
       : feed_comp_(feed_comp), gamma_235_(gamma_235),
         tails_assay_(tails_assay), use_downblending(use_downblending) {}
-  
+
   virtual ~SwuConverter() {}
 
   virtual double convert(
       cyclus::Material::Ptr m, cyclus::Arc const * a = NULL,
-      cyclus::ExchangeTranslationContext<cyclus::Material> 
+      cyclus::ExchangeTranslationContext<cyclus::Material>
           const * ctx = NULL) const {
-    
+
     double product_qty = m->quantity();
     double product_assay = MIsoAtomAssay(m);
     EnrichmentCalculator e(feed_comp_, product_assay, tails_assay_, gamma_235_,
                            1e299, product_qty, 1e299, use_downblending);
     double swu_used = e.SwuUsed();
-    
+
     return swu_used;
   }
 
   virtual bool operator==(Converter& other) const {
     SwuConverter* cast = dynamic_cast<SwuConverter*>(&other);
-    
+
     bool cast_not_null = cast != NULL;
-    bool feed_eq = cyclus::compmath::AlmostEq(feed_comp_->atom(), 
+    bool feed_eq = cyclus::compmath::AlmostEq(feed_comp_->atom(),
                                               cast->feed_comp_->atom(),
                                               kEpsCompMap);
     bool tails_eq = tails_assay_ == cast->tails_assay_;
@@ -62,22 +62,22 @@ class FeedConverter : public cyclus::Converter<cyclus::Material> {
  public:
   FeedConverter(cyclus::Composition::Ptr feed_comp, double tails_assay,
                 double gamma_235, bool use_downblending)
-      : feed_comp_(feed_comp), gamma_235_(gamma_235), 
+      : feed_comp_(feed_comp), gamma_235_(gamma_235),
         tails_assay_(tails_assay), use_downblending(use_downblending) {}
 
   virtual ~FeedConverter() {}
 
   virtual double convert(
       cyclus::Material::Ptr m, cyclus::Arc const * a = NULL,
-      cyclus::ExchangeTranslationContext<cyclus::Material> 
+      cyclus::ExchangeTranslationContext<cyclus::Material>
           const * ctx = NULL) const {
-    
+
     double product_qty = m->quantity();
     double product_assay = MIsoAtomAssay(m);
     EnrichmentCalculator e(feed_comp_, product_assay, tails_assay_, gamma_235_,
                            1e299, product_qty, 1e299, use_downblending);
     double feed_used = e.FeedUsed();
-    
+
     cyclus::toolkit::MatQuery mq(m);
     std::vector<int> isotopes(IsotopesNucID());
     std::set<int> nucs(isotopes.begin(), isotopes.end());
@@ -85,12 +85,12 @@ class FeedConverter : public cyclus::Converter<cyclus::Material> {
 
     return feed_used / feed_uranium_frac;
   }
-  
+
   virtual bool operator==(Converter& other) const {
     FeedConverter* cast = dynamic_cast<FeedConverter*>(&other);
-    
+
     bool cast_not_null = cast != NULL;
-    bool feed_eq = cyclus::compmath::AlmostEq(feed_comp_->atom(), 
+    bool feed_eq = cyclus::compmath::AlmostEq(feed_comp_->atom(),
                                               cast->feed_comp_->atom(),
                                               kEpsCompMap);
     bool tails_eq = tails_assay_ == cast->tails_assay_;
@@ -107,13 +107,13 @@ class FeedConverter : public cyclus::Converter<cyclus::Material> {
 
 /// @class MIsoEnrich
 ///
-/// @section intro 
+/// @section intro
 ///
-/// @section agentparams 
+/// @section agentparams
 ///
 /// @section optionalparams
 ///
-/// @section detailed 
+/// @section detailed
 class MIsoEnrich : public cyclus::Facility,
                    public cyclus::toolkit::Position {
  public:
@@ -122,14 +122,14 @@ class MIsoEnrich : public cyclus::Facility,
   explicit MIsoEnrich(cyclus::Context* ctx);
 
   ~MIsoEnrich();
-  
+
   friend class MIsoEnrichTest;
 
   #pragma cyclus
 
   #pragma cyclus note {"doc": "A stub facility is provided as a skeleton " \
                               "for the design of new facility agents."}
- 
+
   void EnterNotify();
   void Tick();
   void Tock();
@@ -144,29 +144,29 @@ class MIsoEnrich : public cyclus::Facility,
 
 
   std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr>
-      GetMatlBids(cyclus::CommodMap<cyclus::Material>::type& 
+      GetMatlBids(cyclus::CommodMap<cyclus::Material>::type&
                   commod_requests);
-  std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr> 
+  std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
       GetMatlRequests();
   std::string str();
 
  private:
   void AddMat_(cyclus::Material::Ptr mat);
-  
+
   void AddFeedMat_(cyclus::Material::Ptr mat);
 
   cyclus::Material::Ptr Request_();
 
-  // The Offer function only considers U235 content that needs to be 
-  // achieved and it ignores the minor isotopes. This has the advantage 
-  // that the evolution of minor isotopes does not need to be taken into 
+  // The Offer function only considers U235 content that needs to be
+  // achieved and it ignores the minor isotopes. This has the advantage
+  // that the evolution of minor isotopes does not need to be taken into
   // account when performing requests to a MIsoEnrich facility.
   cyclus::Material::Ptr Offer_(cyclus::Material::Ptr req);
 
   cyclus::Material::Ptr Enrich_(cyclus::Material::Ptr mat, double qty);
 
   bool ValidReq_(const cyclus::Material::Ptr& mat);
-  
+
   ///  @brief records and enrichment with the cyclus::Recorder
   void RecordEnrichment_(double feed_qty, double swu, int feed_inv_idx);
 
@@ -283,7 +283,7 @@ class MIsoEnrich : public cyclus::Facility,
   double intra_timestep_feed;
 
   EnrichmentCalculator enrichment_calc;
-  
+
   // TODO think about how to include these variables in preprocessor
   //#pragma cyclus var {}
   std::vector<cyclus::toolkit::ResBuf<cyclus::Material> > feed_inv;
@@ -291,7 +291,7 @@ class MIsoEnrich : public cyclus::Facility,
   std::vector<cyclus::Composition::Ptr> feed_inv_comp;
 
   int feed_idx;
-  
+
   #pragma cyclus var {}
   cyclus::toolkit::ResBuf<cyclus::Material> tails_inv;
 
@@ -300,19 +300,19 @@ class MIsoEnrich : public cyclus::Facility,
     "uilabel": "Geographical latitude in degrees as a double", \
     "doc": "Latitude of the agent's geographical position. The value " \
            "should be expressed in degrees as a double." \
-  } 
+  }
   double latitude;
-  
+
   #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical longitude in degrees as a double", \
     "doc": "Longitude of the agent's geographical position. The value " \
            "should be expressed in degrees as a double." \
-  } 
-  double longitude; 
-  
+  }
+  double longitude;
+
   cyclus::toolkit::Position coordinates;
-  
+
   #pragma cyclus var {  \
     "default": [-1],  \
     "tooltip": "SWU capacity change times in timesteps from beginning " \

--- a/src/miso_enrich_tests.cc
+++ b/src/miso_enrich_tests.cc
@@ -23,7 +23,7 @@ namespace misoenrichment {
 void MIsoEnrichTest::SetUp() {
   cyclus::PyStart();
   cyclus::Env::SetNucDataPath();
-  
+
   fake_sim = new cyclus::MockSim(1);
   miso_enrich_facility = new MIsoEnrich(fake_sim->context());
 
@@ -110,7 +110,7 @@ TEST_F(MIsoEnrichTest, BidPrefs) {
   cyclus::compmath::Normalize(&cm);
   Composition::Ptr feed_2 = Composition::CreateFromMass(cm);
 
-  std::string config = 
+  std::string config =
     "   <feed_commod>feed_U</feed_commod> "
     "   <feed_recipe>feed1</feed_recipe> "
     "   <product_commod>enriched_U</product_commod> "
@@ -123,7 +123,7 @@ TEST_F(MIsoEnrichTest, BidPrefs) {
 
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec(":misoenrichment:MIsoEnrich"),
-                      config, simdur); 
+                      config, simdur);
   sim.AddRecipe("feed1", feed_1);
   sim.AddRecipe("feed2", feed_2);
 
@@ -152,7 +152,7 @@ TEST_F(MIsoEnrichTest, BidPrefs) {
 TEST_F(MIsoEnrichTest, FeedConstraint) {
   // Check that the feed constraint is evaluated correctly. Only 100 kg of
   // feed are at the disposal but the sink requests infinity kg of product.
-  std::string config = 
+  std::string config =
     "   <feed_commod>feed_U</feed_commod> "
     "   <feed_recipe>feed_recipe</feed_recipe> "
     "   <initial_feed>100</initial_feed> "
@@ -167,7 +167,7 @@ TEST_F(MIsoEnrichTest, FeedConstraint) {
   cyclus::MockSim sim(cyclus::AgentSpec(":misoenrichment:MIsoEnrich"),
                       config, simdur);
   sim.AddRecipe(feed_recipe, recipe);
-  sim.AddRecipe("enriched_U_recipe", misotest::comp_weapongradeU()); 
+  sim.AddRecipe("enriched_U_recipe", misotest::comp_weapongradeU());
   sim.AddSink("enriched_U").recipe("enriched_U_recipe")
                            .Finalize();
   int id = sim.Run();
@@ -188,7 +188,7 @@ TEST_F(MIsoEnrichTest, GetMatlBids) {
   // the product is expected. Finally, an enrichment is performed and two
   // bids are expected (one for the product, one for the tails).
   using cyclus::Material;
-  
+
   cyclus::Request<Material> *req_prod, *req_tails;
   cyclus::CommodMap<Material>::type out_requests;
   std::set<cyclus::BidPortfolio<Material>::Ptr> bids;
@@ -198,24 +198,24 @@ TEST_F(MIsoEnrichTest, GetMatlBids) {
   cm[922350000] = 50;
   cm[922380000] = 49.9945;
   Material::Ptr product = Material::CreateUntracked(
-      1, cyclus::Composition::CreateFromMass(cm)); 
+      1, cyclus::Composition::CreateFromMass(cm));
   // Clearing the CompMap is technically not needed but may be clearer.
   cm.clear();
   cm[922350000] = 0.3;
   cm[922380000] = 99.7;
   Material::Ptr tails = Material::CreateUntracked(
       1, cyclus::Composition::CreateFromMass(cm));
-  req_prod = cyclus::Request<Material>::Create(product, miso_enrich_facility, 
+  req_prod = cyclus::Request<Material>::Create(product, miso_enrich_facility,
                                                product_commod);
   req_tails = cyclus::Request<Material>::Create(tails, miso_enrich_facility,
                                                 tails_commod);
-  
+
   out_requests[req_prod->commodity()].push_back(req_prod);
   out_requests[req_tails->commodity()].push_back(req_tails);
-  
+
   ASSERT_NO_THROW(bids = miso_enrich_facility->GetMatlBids(out_requests));
   EXPECT_EQ(0, bids.size());
-  
+
   DoAddMat(GetFeedMat(1000));
   bids = miso_enrich_facility->GetMatlBids(out_requests);
   EXPECT_EQ(1, bids.size());
@@ -257,7 +257,7 @@ TEST_F(MIsoEnrichTest, NoBidPrefs) {
   cm[922380000] = 98.2835;
   Composition::Ptr feed_2 = Composition::CreateFromMass(cm);
 
-  std::string config = 
+  std::string config =
     "   <feed_commod>feed_U</feed_commod> "
     "   <feed_recipe>feed1</feed_recipe> "
     "   <product_commod>enriched_U</product_commod> "
@@ -270,7 +270,7 @@ TEST_F(MIsoEnrichTest, NoBidPrefs) {
     "   <use_downblending>0</use_downblending> ";
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec(":misoenrichment:MIsoEnrich"),
-                      config, simdur); 
+                      config, simdur);
   sim.AddRecipe("feed1", feed_1);
   sim.AddRecipe("feed2", feed_2);
 
@@ -299,12 +299,12 @@ TEST_F(MIsoEnrichTest, Request) {
   // Test correctness of quantities and materials requested
   double req_qty = inv_size - initial_feed;
   double add_qty;
- 
+
   // Only initially added material in inventory
   cyclus::Material::Ptr mat = DoRequest();
   EXPECT_DOUBLE_EQ(mat->quantity(), req_qty);
   EXPECT_EQ(mat->comp(), recipe);
-  
+
   // Full inventory
   add_qty = req_qty;
   ASSERT_NO_THROW(DoAddMat(GetFeedMat(add_qty)));
@@ -320,7 +320,7 @@ TEST_F(MIsoEnrichTest, RequestSim) {
   // Check that exactly as much material as needed is requested in exactly
   // one request.
 
-  std::string config = 
+  std::string config =
     "   <feed_commod>feed_U</feed_commod> "
     "   <feed_recipe>feed_recipe</feed_recipe> "
     "   <product_commod>enriched_U</product_commod> "
@@ -334,7 +334,7 @@ TEST_F(MIsoEnrichTest, RequestSim) {
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec(":misoenrichment:MIsoEnrich"),
                       config, simdur);
-  
+
   sim.AddRecipe(feed_recipe, recipe);
   sim.AddSource("feed_U").recipe("feed_recipe").Finalize();
 
@@ -351,7 +351,7 @@ TEST_F(MIsoEnrichTest, RequestSim) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MIsoEnrichTest, TailsTrade) {
-  std::string config = 
+  std::string config =
     "   <feed_commod>feed_U</feed_commod> "
     "   <feed_recipe>feed_recipe</feed_recipe> "
     "   <product_commod>enriched_U</product_commod> "
@@ -372,7 +372,7 @@ TEST_F(MIsoEnrichTest, TailsTrade) {
                            .Finalize();
   sim.AddSink("depleted_U").recipe("depleted_U_recipe")
                            .Finalize();
-  
+
   int id = sim.Run();
 
   std::vector<Cond> conds;
@@ -380,7 +380,7 @@ TEST_F(MIsoEnrichTest, TailsTrade) {
   QueryResult qr = sim.db().Query("Transactions", &conds);
   cyclus::Material::Ptr mat = sim.GetMaterial(
       qr.GetVal<int>("ResourceId"));
-  
+
   EXPECT_EQ(1, qr.rows.size());
   EXPECT_NEAR(99.4246, mat->quantity(), 1e-4);
 }
@@ -407,7 +407,7 @@ TEST_F(MIsoEnrichTest, ValidRequest) {
   cm[922340000] = 0.5;
   cm[922350000] = 0.5;
   Composition::Ptr comp_no_U238 = Composition::CreateFromMass(cm);
- 
+
   Material::Ptr naturalU = Material::CreateUntracked(1, recipe);
   Material::Ptr depletedU = Material::CreateUntracked(1, comp_depletedU());
   Material::Ptr no_U238 = Material::CreateUntracked(1, comp_no_U238);

--- a/src/miso_enrich_tests.cc
+++ b/src/miso_enrich_tests.cc
@@ -161,7 +161,8 @@ TEST_F(MIsoEnrichTest, FeedConstraint) {
     "   <tails_assay>0.002</tails_assay> "
     "   <swu_capacity_times><val>0</val></swu_capacity_times> "
     "   <swu_capacity_vals><val>10000</val></swu_capacity_vals> "
-    "   <use_downblending>0</use_downblending> ";
+    "   <use_downblending>0</use_downblending> "
+    "   <use_integer_stages>1</use_integer_stages> ";
 
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec(":misoenrichment:MIsoEnrich"),
@@ -267,7 +268,8 @@ TEST_F(MIsoEnrichTest, NoBidPrefs) {
     "   <order_prefs>1</order_prefs>"
     "   <swu_capacity_times><val>0</val></swu_capacity_times> "
     "   <swu_capacity_vals><val>10000</val></swu_capacity_vals> "
-    "   <use_downblending>0</use_downblending> ";
+    "   <use_downblending>0</use_downblending> "
+    "   <use_integer_stages>1</use_integer_stages> ";
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec(":misoenrichment:MIsoEnrich"),
                       config, simdur);
@@ -330,7 +332,8 @@ TEST_F(MIsoEnrichTest, RequestSim) {
     "   <max_enrich>0.8</max_enrich> "
     "   <swu_capacity_times><val>0</val></swu_capacity_times> "
     "   <swu_capacity_vals><val>10000</val></swu_capacity_vals> "
-    "   <use_downblending>0</use_downblending> ";
+    "   <use_downblending>0</use_downblending> "
+    "   <use_integer_stages>1</use_integer_stages> ";
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec(":misoenrichment:MIsoEnrich"),
                       config, simdur);
@@ -360,7 +363,8 @@ TEST_F(MIsoEnrichTest, TailsTrade) {
     "   <initial_feed>100</initial_feed> "
     "   <swu_capacity_times><val>0</val></swu_capacity_times> "
     "   <swu_capacity_vals><val>10000</val></swu_capacity_vals> "
-    "   <use_downblending>0</use_downblending> ";
+    "   <use_downblending>0</use_downblending> "
+    "   <use_integer_stages>1</use_integer_stages> ";
   int simdur = 2;
   cyclus::MockSim sim(cyclus::AgentSpec(":misoenrichment:MIsoEnrich"),
                       config, simdur);

--- a/src/miso_enrich_tests.h
+++ b/src/miso_enrich_tests.h
@@ -15,10 +15,10 @@ namespace misoenrichment {
 class MIsoEnrichTest : public ::testing::Test {
  protected:
   MIsoEnrich* miso_enrich_facility;
-  
+
   cyclus::MockSim* fake_sim;
   cyclus::Composition::Ptr recipe;
-  
+
   bool order_prefs;
   double gamma_235, initial_feed, inv_size, latitude, longitude,
          max_enrich, swu_capacity, tails_assay;
@@ -26,17 +26,17 @@ class MIsoEnrichTest : public ::testing::Test {
   std::string feed_commod, product_commod, tails_commod, feed_recipe;
   std::vector<double> swu_vals;
   std::vector<int> swu_times;
-  
+
   // Functions to initialise and end each test
   void SetUp();
   void TearDown();
   void InitParameters();
   void SetUpMIsoEnrichment();
-  
+
   // Helper functions
   cyclus::Material::Ptr GetFeedMat(double qty);
 
-  // The Do* functions are a hack: MIsoEnrichTest is a friend class to 
+  // The Do* functions are a hack: MIsoEnrichTest is a friend class to
   // MIsoEnrich and it can therefore access private functions. However,
   // all of the tests are sub-classes of the fixture and they cannot access
   // the private functions, hence we need to use the Do* functions as an
@@ -51,7 +51,7 @@ class MIsoEnrichTest : public ::testing::Test {
   inline void DoAddMat(cyclus::Material::Ptr mat) {
     miso_enrich_facility->AddMat_(mat);
   }
-  inline void DoAddFeedMat(cyclus::Material::Ptr mat) { 
+  inline void DoAddFeedMat(cyclus::Material::Ptr mat) {
     miso_enrich_facility->AddFeedMat_(mat);
   }
   inline void DoEnrich(cyclus::Material::Ptr mat, double qty) {

--- a/src/miso_helper.cc
+++ b/src/miso_helper.cc
@@ -20,9 +20,9 @@ bool CompareCompMap(cyclus::CompMap cm1, cyclus::CompMap cm2) {
   for (it = isotopes.begin(); it != isotopes.end(); it++) {
     cm1[*it] += 1e-299;
     cm2[*it] += 1e-299;
-  }  
+  }
 
-  bool result = cyclus::compmath::AlmostEq(cm1, cm2, kEpsCompMap); 
+  bool result = cyclus::compmath::AlmostEq(cm1, cm2, kEpsCompMap);
   if (!result) {
     std::cout << "Value of: cm1\n"
               << "Actual:\n";
@@ -54,15 +54,15 @@ cyclus::Composition::Ptr comp_natU() {
   comp[922340000] = 5.5e-3;
   comp[922350000] = 0.711;
   comp[922380000] = 99.2835;
-  
+
   return cyclus::Composition::CreateFromMass(comp);
 };
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 cyclus::Composition::Ptr comp_reprocessedU() {
-  // Composition taken from Exploring Uranium Resource Constraints on 
-  // Fissile Material Production in Pakistan. Zia Mian, A. H. Nayyar and 
-  // R. Rajaraman. Science and Global Security 17, 2009: p.87. 
+  // Composition taken from Exploring Uranium Resource Constraints on
+  // Fissile Material Production in Pakistan. Zia Mian, A. H. Nayyar and
+  // R. Rajaraman. Science and Global Security 17, 2009: p.87.
   // DOI: 10.1080/08929880902975834
 
   cyclus::CompMap comp;
@@ -101,7 +101,7 @@ const std::vector<int> IsotopesNucID() {
   std::vector<int> isotopes(iso, iso + sizeof(iso)/sizeof(int));
   for (int& i : isotopes) {
     i = (92*1000 + i) * 10000;
-  } 
+  }
   return isotopes;
 }
 
@@ -109,7 +109,7 @@ const std::vector<int> IsotopesNucID() {
 int IsotopeToNucID(int isotope) {
   std::vector<int> isotopes = {232, 233, 234, 235, 236, 238};
   std::vector<int>::iterator it;
-  
+
   it = std::find(isotopes.begin(), isotopes.end(), isotope);
   if (it == isotopes.end()) {
     throw cyclus::ValueError("Invalid (non-uranium) isotope!");
@@ -121,7 +121,7 @@ int IsotopeToNucID(int isotope) {
 int NucIDToIsotope(int nuc_id) {
   std::vector<int> isotopes(IsotopesNucID());
   std::vector<int>::iterator it;
-  
+
   it = std::find(isotopes.begin(), isotopes.end(), nuc_id);
   if (it == isotopes.end()) {
     throw cyclus::ValueError("Invalid (non-uranium) isotope!");
@@ -139,7 +139,7 @@ int ResBufIdx(
   for (const cyclus::Composition::Ptr& buf_comp : buf_compositions) {
     cyclus::CompMap buf_compmap = buf_comp->atom();
     cyclus::compmath::Normalize(&buf_compmap);
-    
+
     if (cyclus::compmath::AlmostEq(in_compmap, buf_compmap, kEpsCompMap)) {
       int i = &buf_comp - &buf_compositions[0];
       return i;
@@ -169,7 +169,7 @@ double MIsoMassAssay(cyclus::Material::Ptr rsrc) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-double MIsoAtomFrac(cyclus::Composition::Ptr composition, 
+double MIsoAtomFrac(cyclus::Composition::Ptr composition,
                             int isotope) {
   return MIsoFrac(composition->atom(), isotope);
 }
@@ -180,11 +180,11 @@ double MIsoAtomFrac(cyclus::Material::Ptr rsrc, int isotope) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-double MIsoMassFrac(cyclus::Composition::Ptr composition, 
+double MIsoMassFrac(cyclus::Composition::Ptr composition,
                             int isotope) {
   return MIsoFrac(composition->mass(), isotope);
 }
-  
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 double MIsoMassFrac(cyclus::Material::Ptr rsrc, int isotope) {
   return MIsoMassFrac(rsrc->comp(), isotope);
@@ -198,16 +198,16 @@ double MIsoAssay(cyclus::CompMap compmap) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 double MIsoFrac(cyclus::CompMap compmap, int isotope) {
   std::vector<int> isotopes(IsotopesNucID());
-  
+
   double isotope_assay = 0;
   double uranium_atom_frac = 0;
-  
+
   if (isotope < 10010000) {
     std::stringstream ss;
     ss << "Isotope id '" << isotope << "'is not a valid NucID!";
     throw cyclus::ValueError(ss.str());
   }
-  // Get total uranium mole fraction, all non-uranium elements are not 
+  // Get total uranium mole fraction, all non-uranium elements are not
   // considered here as they are directly sent to the tails.
   for (int i : isotopes) {
     if (compmap.find(i) != compmap.end()) {

--- a/src/miso_helper.h
+++ b/src/miso_helper.h
@@ -40,23 +40,23 @@ double MIsoMassAssay(cyclus::Material::Ptr rsrc);
 double MIsoAtomFrac(cyclus::Composition::Ptr composition,
                             int isotope);
 double MIsoAtomFrac(cyclus::Material::Ptr rsrc, int isotope);
-double MIsoMassFrac(cyclus::Composition::Ptr composition, 
+double MIsoMassFrac(cyclus::Composition::Ptr composition,
                             int isotope);
 double MIsoMassFrac(cyclus::Material::Ptr rsrc, int isotope);
 
 double MIsoAssay(cyclus::CompMap compmap);
 double MIsoFrac(cyclus::CompMap compmap, int isotope);
 
-// Calculates the stage separation factor for all isotopes starting from 
+// Calculates the stage separation factor for all isotopes starting from
 // the given U235 overall separation factor.
 //
 // Returns a map containing the stage separation factors for all U isotopes
 // with the keys being the isotopes' mass.
 //
-// Note that the stage separation factor is defined as the ratio of 
-// abundance ratio in product to abundance ratio in tails. This method 
-// follows Houston G. Wood 'Effects of Separation Processes on Minor 
-// Uranium Isotopes in Enrichment Cascades'. In: Science and Global 
+// Note that the stage separation factor is defined as the ratio of
+// abundance ratio in product to abundance ratio in tails. This method
+// follows Houston G. Wood 'Effects of Separation Processes on Minor
+// Uranium Isotopes in Enrichment Cascades'. In: Science and Global
 // Security, 16:26--36 (2008). ISSN: 0892-9882.
 // DOI: 10.1080/08929880802361796
 std::map<int,double> CalculateSeparationFactor(double gamma_235);

--- a/src/miso_helper_tests.cc
+++ b/src/miso_helper_tests.cc
@@ -14,7 +14,7 @@ TEST(MIsoHelperTest, ChooseCorrectResBuf) {
   std::vector<Composition::Ptr> comp_vec;
   comp_vec.push_back(misotest::comp_natU());
   comp_vec.push_back(misotest::comp_weapongradeU());
-  
+
   cyclus::CompMap plutonium_cm;
   plutonium_cm[942390000] = 1.;
   Composition::Ptr plutonium = Composition::CreateFromAtom(plutonium_cm);
@@ -26,7 +26,7 @@ TEST(MIsoHelperTest, ChooseCorrectResBuf) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST(MIsoHelperTest, NucIDConversion) {
   std::vector<int> isotopes(IsotopesNucID());
-  
+
   for (int i : isotopes) {
     int isotope = NucIDToIsotope(i);
     EXPECT_EQ(IsotopeToNucID(isotope), i);
@@ -79,7 +79,7 @@ TEST(MIsoHelperTest, SeparationFactor) {
   expected[922350000] = 1.6;
   expected[922360000] = 1.4;
   expected[922380000] = 1.0;
-  
+
   for (int i : isotopes) {
     EXPECT_DOUBLE_EQ(separation_factor[i], expected[i]);
   }


### PR DESCRIPTION
Add the possibility to have non-integer (i.e., decimal) number of stages in enriching and stripping sections. This allows to precisely model the matched abundance ratio cascade (the multi-component equivalent of the ideal cascade)

**To do's**

- [x] Add external libraries
- [x] Implement formulae and minimisation process
- [x] Add tests to ensure correctness of the implementation